### PR TITLE
Create python AST from string instead of file

### DIFF
--- a/translate/py_main.py
+++ b/translate/py_main.py
@@ -10,7 +10,7 @@ sys.path.append('routers')
 import py_router
 
 """
-takes pyton file and converts it to a node
+takes pyton string and converts it to a node
 node is then dealt with by node_to_gast 
 """
 def py_to_gast(python_input):
@@ -18,6 +18,6 @@ def py_to_gast(python_input):
     print(astor.dump_tree(input_ast))
     return py_router.node_to_gast(input_ast)
 
-file = "print('hello world')"
-gast = py_to_gast(file)
+python_input = "print('hello world')"
+gast = py_to_gast(python_input)
 print(gast)

--- a/translate/py_main.py
+++ b/translate/py_main.py
@@ -13,11 +13,11 @@ import py_router
 takes pyton file and converts it to a node
 node is then dealt with by node_to_gast 
 """
-def py_to_gast(python_input_filename):
-    input_ast =  astor.code_to_ast.parse_file(python_input_filename)
+def py_to_gast(python_input):
+    input_ast = ast.parse(python_input)
     print(astor.dump_tree(input_ast))
     return py_router.node_to_gast(input_ast)
 
-fileName = "py_sample_code.py"
-gast = py_to_gast(fileName)
+file = "print('hello world')"
+gast = py_to_gast(file)
 print(gast)

--- a/translate/py_sample_code.py
+++ b/translate/py_sample_code.py
@@ -1,1 +1,0 @@
-print("hello world")


### PR DESCRIPTION
Use ast library instead of astor library to create python AST so we can use a string instead of file to build. Still works as expected and can print a "pretty" version of AST using astor.dump_tree().