### PR TITLE
Add language choice functionality to POST request

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,16 +18,29 @@ api = Api(app)
 CORS(app)
 
 parser = reqparse.RequestParser()
-parser.add_argument('input')
+parser.add_argument('in_code')
+parser.add_argument('in_lang')
+parser.add_argument('out_lang')
 
 class Translate(Resource):
     def get(self):
         return {'work': 'ing'}
 
     def post(self):
+        # bring in post arguments
         args = parser.parse_args()
-        input_text = args['input']
-        gast = js_main.js_to_gast(input_text)
+        input_code = args['in_code']
+        input_lang = args['in_lang']
+        output_lang = args['out_lang']
+
+        print(input_code, input_lang, output_lang)
+        if input_lang == "js":
+            gast = js_main.js_to_gast(input_code)
+        elif input_lang == "py":
+            pass # TODO: fill this in
+        else:
+            return {"Error": "must specify valid input language"}
+        
         output_code = gast_to_py.gast_to_py(gast)
         return {'response': output_code}
 

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ sys.path.append('translate/helpers')
 sys.path.append('translate/routers')
 
 import js_main as js_main
+import py_main as py_main
 import gast_to_py as gast_to_py
 import gast_to_code as gtc
 
@@ -38,7 +39,7 @@ class Translate(Resource):
         if input_lang == "js":
             gast = js_main.js_to_gast(input_code)
         elif input_lang == "py":
-            pass # TODO: fill this in
+            gast = py_main.py_to_gast(input_code)
         else:
             return {"Error": "must specify valid input language"}
 

--- a/app.py
+++ b/app.py
@@ -40,7 +40,6 @@ class Translate(Resource):
             input_lang = "js"
             output_lang = "py"
 
-        print(input_code, input_lang, output_lang)
         if input_lang == "js":
             gast = js_main.js_to_gast(input_code)
         elif input_lang == "py":

--- a/app.py
+++ b/app.py
@@ -1,19 +1,7 @@
 from flask import Flask
 from flask_restful import Resource, Api, reqparse
 from flask_cors import CORS
-import sys
-
-sys.path.append('translate')
-sys.path.append('translate/assign')
-sys.path.append('translate/expression')
-sys.path.append('translate/helpers')
-sys.path.append('translate/routers')
-
-import js_main as js_main
-import py_main as py_main
-import gast_to_py as gast_to_py
-import gast_to_code as gtc
-
+from main import main
 
 app = Flask(__name__)
 api = Api(app)
@@ -35,19 +23,7 @@ class Translate(Resource):
         input_lang = args['in_lang']
         output_lang = args['out_lang']
 
-        # TODO: remove this once frontend is updated
-        if input_lang == None and output_lang == None:
-            input_lang = "js"
-            output_lang = "py"
-
-        if input_lang == "js":
-            gast = js_main.js_to_gast(input_code)
-        elif input_lang == "py":
-            gast = py_main.py_to_gast(input_code)
-        else:
-            return {"Error": "must specify valid input language"}
-
-        output_code = gtc.gast_router(gast, output_lang)
+        output_code = main(input_code, input_lang, output_lang)
 
         return {'response': output_code}
 

--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ sys.path.append('translate/routers')
 
 import js_main as js_main
 import gast_to_py as gast_to_py
+import gast_to_code as gtc
 
 
 app = Flask(__name__)
@@ -40,8 +41,9 @@ class Translate(Resource):
             pass # TODO: fill this in
         else:
             return {"Error": "must specify valid input language"}
-        
-        output_code = gast_to_py.gast_to_py(gast)
+
+        output_code = gtc.gast_router(gast, output_lang)
+
         return {'response': output_code}
 
 api.add_resource(Translate, '/')

--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ api = Api(app)
 CORS(app)
 
 parser = reqparse.RequestParser()
-parser.add_argument('in_code')
+parser.add_argument('input')
 parser.add_argument('in_lang')
 parser.add_argument('out_lang')
 
@@ -31,9 +31,14 @@ class Translate(Resource):
     def post(self):
         # bring in post arguments
         args = parser.parse_args()
-        input_code = args['in_code']
+        input_code = args['input']
         input_lang = args['in_lang']
         output_lang = args['out_lang']
+
+        # TODO: remove this once frontend is updated
+        if input_lang == None and output_lang == None:
+            input_lang = "js"
+            output_lang = "py"
 
         print(input_code, input_lang, output_lang)
         if input_lang == "js":

--- a/gast_to_code.py
+++ b/gast_to_code.py
@@ -67,37 +67,3 @@ def gast_router(gast, out_lang):
 
     elif gast["type"] == "varAssign":
         return out["varAssign"][out_lang](gast)
-
-
-# EXAMPLE
-
-example_gast =  {
-            "type": "root",
-            "body": [
-                {
-                    "type": "logStatement",
-                    "args": ["hello world", "hi", 3]
-                },
-                {
-                    "type": "varAssign",
-                    "varId": "x",
-                    "varValue": 5
-                }
-            ]   
-        }
-
-#EXAMPLE Python
-print(gast_router(example_gast, "py"))
-"""
-output:
-    print(hello world, hi, 3)
-    x = 5
-"""
-
-#EXAMPLE javascript
-print(gast_router(example_gast, "js"))
-"""
-output:
-    console.log(hello world, hi, 3)
-    const x = 5
-"""

--- a/main.py
+++ b/main.py
@@ -18,16 +18,18 @@ output_lang: string representing output language of code
 return: string representing output code or error message
 """
 def main(input_code, input_lang, output_lang):
-    # TODO: remove this once frontend is updated
+    # TODO: eventually replace this with 400 error
     if input_lang == None and output_lang == None:
         input_lang = "js"
         output_lang = "py"
 
+    #TODO: also do error checking on the output language
     if input_lang == "js":
         gast = js_main.js_to_gast(input_code)
     elif input_lang == "py":
         gast = py_main.py_to_gast(input_code)
     else:
+        #TODO: figure out hwo to do error messages
         return "Error must specify language. For example, js for javascript and py for python"
 
     output_code = gtc.gast_router(gast, output_lang)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,35 @@
+import sys
+
+sys.path.append('translate')
+sys.path.append('translate/assign')
+sys.path.append('translate/expression')
+sys.path.append('translate/helpers')
+sys.path.append('translate/routers')
+
+import js_main
+import py_main
+import gast_to_py
+import gast_to_code as gtc
+
+"""
+input_code: string representing input code
+input_lang: string representing input language of code
+output_lang: string representing output language of code
+return: string representing output code or error message
+"""
+def main(input_code, input_lang, output_lang):
+    # TODO: remove this once frontend is updated
+    if input_lang == None and output_lang == None:
+        input_lang = "js"
+        output_lang = "py"
+
+    if input_lang == "js":
+        gast = js_main.js_to_gast(input_code)
+    elif input_lang == "py":
+        gast = py_main.py_to_gast(input_code)
+    else:
+        return "Error must specify language. For example, js for javascript and py for python"
+
+    output_code = gtc.gast_router(gast, output_lang)
+
+    return output_code

--- a/translate/expression/py_expression.py
+++ b/translate/expression/py_expression.py
@@ -26,10 +26,10 @@ def call(node):
 """
 takes ast.name node from python ast and converts to string 
 represenation for the generic ast
+FIXME: this should prob be in helpers since it is also used by assign
 """
 def name(node):
     if node.id == "print":
         return "logStatement"
     else:
-        return "customStatement"
-      
+        return node.id      

--- a/translate/expression/py_expression.py
+++ b/translate/expression/py_expression.py
@@ -29,6 +29,7 @@ represenation for the generic ast
 FIXME: this should prob be in helpers since it is also used by assign
 """
 def name(node):
+    #FIXME: prob going to have type issues since logstatement is very different than node.id
     if node.id == "print":
         return "logStatement"
     else:

--- a/translate/js_main.py
+++ b/translate/js_main.py
@@ -9,8 +9,6 @@ sys.path.append('routers')
 
 import js_router as router
 
-program = "let my_container = 20\n console.log('eh')"
-
 def js_to_gast(program):
     input_ast = esprima.parseScript(program, {"tokens": True})
     # TODO: can add more fields to the generic ast

--- a/translate/py_main.py
+++ b/translate/py_main.py
@@ -17,7 +17,3 @@ def py_to_gast(python_input):
     input_ast = ast.parse(python_input)
     print(astor.dump_tree(input_ast))
     return py_router.node_to_gast(input_ast)
-
-python_input = "print('hello world')"
-gast = py_to_gast(python_input)
-print(gast)

--- a/translate/py_main.py
+++ b/translate/py_main.py
@@ -9,7 +9,7 @@ sys.path.append('routers')
 import py_router
 
 """
-takes pyton string and converts it to a node
+takes pyton code and converts it to a node
 node is then dealt with by node_to_gast 
 """
 def py_to_gast(python_input):

--- a/translate/py_main.py
+++ b/translate/py_main.py
@@ -1,6 +1,5 @@
 import sys
 import ast
-import astor
 
 sys.path.append('assign')
 sys.path.append('expression')
@@ -15,9 +14,4 @@ node is then dealt with by node_to_gast
 """
 def py_to_gast(python_input):
     input_ast = ast.parse(python_input)
-    print(astor.dump_tree(input_ast))
     return py_router.node_to_gast(input_ast)
-
-python_input = "x=5"
-gast = py_to_gast(python_input)
-print(gast)

--- a/translate/py_main.py
+++ b/translate/py_main.py
@@ -17,3 +17,7 @@ def py_to_gast(python_input):
     input_ast = ast.parse(python_input)
     print(astor.dump_tree(input_ast))
     return py_router.node_to_gast(input_ast)
+
+python_input = "x=5"
+gast = py_to_gast(python_input)
+print(gast)


### PR DESCRIPTION
Before, POST request was only able to handle translations from js to py. By adding in_lang and out_lang in the POST request, it is able to translate btwn js and py as well as btwn py and js. This was only possible because of [work done](https://github.com/jackdavidweber/cjs_capstone/tree/stringToAST) by @swalsh15 to allow python to gast to use a string as an input

Here is an example of how the post request looks in action.
![image](https://user-images.githubusercontent.com/19896216/85639617-1c76d980-b63e-11ea-9ca5-c48fb115edcf.png)

Note: I added in some logic so that the current frontend request to the backend should still work. I will deploy so that we can edit the request whenever.