### PR TITLE
Type restructure js to gast

### DIFF
--- a/translate/assign/js_assign.py
+++ b/translate/assign/js_assign.py
@@ -8,6 +8,7 @@ def jsassign_to_gast(node):
   gast = {}
   gast["type"] = "varAssign"
   # only works with single assignment
-  gast["varId"] = js_router.node_to_gast(node[0].id)
-  gast["varValue"] = js_helpers.jsarg_to_str(node[0].init)
+  gast["kind"] = node.kind
+  gast["varId"] = js_router.node_to_gast(node.declarations[0].id)
+  gast["varValue"] = js_router.node_to_gast(node.declarations[0].init)
   return gast

--- a/translate/expression/js_expression.py
+++ b/translate/expression/js_expression.py
@@ -1,26 +1,6 @@
 import js_helpers
 import js_router
 
-"""
-Takes javascript expressions and converts them to the generic
-ast format
-"""
-def jsexpr_to_gast(node):
-    gast = {}
-    if node.type == "CallExpression":
-        # handle callee
-        if node.callee.type == "MemberExpression":
-            if (js_helpers.memExp_to_str(node.callee) == "console.log"):
-                gast["type"] = "logStatement"
-            else:
-                gast["type"] = "customStatement"
-        else:
-            gast["type"] = "customStatement"
-
-        # handle args
-        gast["args"] = js_helpers.jsargs_to_strlist(node.arguments)
-    return gast
-
 def convert_expression_to_gast(node):
     return js_router.node_to_gast(node.expression)
 

--- a/translate/helpers/js_helpers.py
+++ b/translate/helpers/js_helpers.py
@@ -17,6 +17,12 @@ def jsarg_to_str(arg):
   else:
     return ""
 
+def js_array_expression(node):
+    gast = {"type" : "arr"}
+    gast["elts"] = []
+    for elm in node.elements:
+        gast["elts"].append(js_router.node_to_gast(elm))
+    return gast
 """
 takes ast node of type program and returns
 a generic ast for that node

--- a/translate/helpers/js_helpers.py
+++ b/translate/helpers/js_helpers.py
@@ -54,6 +54,7 @@ def binOp(bop):
       gast["right"] = js_router.node_to_gast(bop.right)
   return gast
 
+# TODO: address gharel comment https://github.com/jackdavidweber/cjs_capstone/pull/32#discussion_r446407392
 def boolOp(node):
     gast = {"type": "boolOp"}
     if node.left.type != "LogicalExpression" and node.right.type != "LogicalExpression":

--- a/translate/helpers/js_helpers.py
+++ b/translate/helpers/js_helpers.py
@@ -36,23 +36,39 @@ def program_to_gast(node):
     return gast
 
 """
-converts a python ast BinOp and converts it to a readable string recursively 
+converts a python ast BinOp and converts it to a gast node
 """
-def binOp_to_str(bop):
+def binOp(bop):
   gast = {"type" : "binOp"}
   if bop.left.type != "BinaryExpression" and bop.right.type != "BinaryExpression":
       gast["left"] = js_router.node_to_gast(bop.left)
-      gast["operator"] = bop.operator
+      gast["op"] = bop.operator
       gast["right"] = js_router.node_to_gast(bop.right)
   if bop.left.type == "BinaryExpression":
-      gast["left"] = binOp_to_str(bop.left)
-      gast["operator"] = bop.operator
+      gast["left"] = binOp(bop.left)
+      gast["op"] = bop.operator
       gast["right"] = js_router.node_to_gast(bop.right)
   if bop.right.type == "BinaryExpression":
-      gast["left"] = binOp_to_str(bop.left)
-      gast["operator"] = bop.operator
+      gast["left"] = binOp(bop.left)
+      gast["op"] = bop.operator
       gast["right"] = js_router.node_to_gast(bop.right)
   return gast
+
+def boolOp(node):
+    gast = {"type": "boolOp"}
+    if node.left.type != "LogicalExpression" and node.right.type != "LogicalExpression":
+        gast["left"] = js_router.node_to_gast(node.left)
+        gast["op"] = node.operator
+        gast["right"] = js_router.node_to_gast(node.right)
+    elif node.left.type == "LogicalExpression":
+        gast["left"] = boolOp(node.left)
+        gast["op"] = node.operator
+        gast["right"] = js_router.node_to_gast(node.right)
+    elif node.right.type == "LogicalExpression":
+        gast["left"] = js_router.node_to_gast(node.left)
+        gast["op"] = node.operator
+        gast["right"] = boolOp(node.right)
+    return gast
 
 """
 Converts Member Expression and converts to readable string recursively

--- a/translate/helpers/js_helpers.py
+++ b/translate/helpers/js_helpers.py
@@ -39,12 +39,20 @@ def program_to_gast(node):
 converts a python ast BinOp and converts it to a readable string recursively 
 """
 def binOp_to_str(bop):
+  gast = {"type" : "binOp"}
+  if bop.left.type != "BinaryExpression" and bop.right.type != "BinaryExpression":
+      gast["left"] = js_router.node_to_gast(bop.left)
+      gast["operator"] = bop.operator
+      gast["right"] = js_router.node_to_gast(bop.right)
   if bop.left.type == "BinaryExpression":
-    s = binOp_to_str(bop.left) + bop.operator + bop.right.raw
-  else:
-    # base case: if left is just a number, operate on left wrt right
-    s = bop.left.raw + bop.operator + bop.right.raw
-  return s
+      gast["left"] = binOp_to_str(bop.left)
+      gast["operator"] = bop.operator
+      gast["right"] = js_router.node_to_gast(bop.right)
+  if bop.right.type == "BinaryExpression":
+      gast["left"] = binOp_to_str(bop.left)
+      gast["operator"] = bop.operator
+      gast["right"] = js_router.node_to_gast(bop.right)
+  return gast
 
 """
 Converts Member Expression and converts to readable string recursively

--- a/translate/js_main.py
+++ b/translate/js_main.py
@@ -13,10 +13,10 @@ import js_router
 takes js string and converts it to a generic AST
 """
 def js_to_gast(js_input):
-    try:
+    #try:
         input_ast = esprima.parseScript(js_input, {"tokens": False})
         return js_router.node_to_gast(input_ast)
-    except:
-        return "Error: code could not compile"
+    #except:
+     #  return "Error: code could not compile"
 
-#print(js_to_gast("x.+"))
+print(js_to_gast("['hello', [1, 2]]"))

--- a/translate/js_main.py
+++ b/translate/js_main.py
@@ -19,4 +19,4 @@ def js_to_gast(js_input):
     except:
         return "Error: code could not compile"
 
-print(js_to_gast("1 * 2 + 3 * 4"))
+print(js_to_gast("true || true || false && true"))

--- a/translate/js_main.py
+++ b/translate/js_main.py
@@ -19,4 +19,4 @@ def js_to_gast(js_input):
     except:
         return "Error: code could not compile"
 
-print(js_to_gast("true || true || false && true"))
+print(js_to_gast("(1 + 2) && 3"))

--- a/translate/js_main.py
+++ b/translate/js_main.py
@@ -19,4 +19,4 @@ def js_to_gast(js_input):
     #except:
      #  return "Error: code could not compile"
 
-print(js_to_gast("['hello', [1, 2]]"))
+print(js_to_gast("console.log(true)"))

--- a/translate/js_main.py
+++ b/translate/js_main.py
@@ -13,10 +13,10 @@ import js_router
 takes js string and converts it to a generic AST
 """
 def js_to_gast(js_input):
-    #try:
+    try:
         input_ast = esprima.parseScript(js_input, {"tokens": False})
         return js_router.node_to_gast(input_ast)
-    #except:
-     #  return "Error: code could not compile"
+    except:
+        return "Error: code could not compile"
 
-print(js_to_gast("console.log(true)"))
+print(js_to_gast("1 * 2 + 3 * 4"))

--- a/translate/routers/js_router.py
+++ b/translate/routers/js_router.py
@@ -13,7 +13,19 @@ def node_to_gast(node):
         return js_helpers.node_list(node)
     # base cases
     if node.type == "Literal":
-        return node.value
+        # must check bool first since bool is instance of int
+        if isinstance(node.value, bool):
+            if node.raw == "true":
+                node.value = 0
+            else:
+                node.value = 1
+            return {"type": "bool", "value": node.value}
+        elif isinstance(node.value, int):
+            return {"type": "num", "value": node.value}
+        elif isinstance(node.value, str):
+            return {"type": "str", "value": node.value}
+        else:
+            return "Unsupported prim"
     elif node.type == "Identifier":
         # identifier has quotes around name
         return node.name
@@ -31,7 +43,7 @@ def node_to_gast(node):
     elif node.type == "Program":
         return js_helpers.program_to_gast(node)
     elif node.type == "ArrayExpression":
-        return js_helpers.jsarg_to_str(node)
+        return js_helpers.js_array_expression(node)
     else:
         # not supported
         return "No match"

--- a/translate/routers/js_router.py
+++ b/translate/routers/js_router.py
@@ -30,7 +30,9 @@ def node_to_gast(node):
         # identifier has quotes around name
         return node.name
     elif node.type == "BinaryExpression":
-        return js_helpers.binOp_to_str(node)
+        return js_helpers.binOp(node)
+    elif node.type == "LogicalExpression":
+        return js_helpers.boolOp(node)
     #statements
     elif node.type == "VariableDeclaration":
         return js_assign.jsassign_to_gast(node)
@@ -46,6 +48,7 @@ def node_to_gast(node):
         return js_helpers.js_array_expression(node)
     else:
         # not supported
+        print(node.type)
         return "No match"
 
 

--- a/translate/routers/js_router.py
+++ b/translate/routers/js_router.py
@@ -16,9 +16,9 @@ def node_to_gast(node):
         # must check bool first since bool is instance of int
         if isinstance(node.value, bool):
             if node.raw == "true":
-                node.value = 0
-            else:
                 node.value = 1
+            else:
+                node.value = 0
             return {"type": "bool", "value": node.value}
         elif isinstance(node.value, int):
             return {"type": "num", "value": node.value}
@@ -33,7 +33,7 @@ def node_to_gast(node):
         return js_helpers.binOp_to_str(node)
     #statements
     elif node.type == "VariableDeclaration":
-        return js_assign.jsassign_to_gast(node.declarations)
+        return js_assign.jsassign_to_gast(node)
     elif node.type == "ExpressionStatement":
         return js_expression.convert_expression_to_gast(node)
     elif node.type == "CallExpression":


### PR DESCRIPTION
Literal values are now stored with primitive type in generic ast (num, bool, string). Added support for array declarations and binary and boolean operations. General AST now takes a nested format. Removed old iterative helper functions for arrays.