### PR TITLE
Gast to code bin op

### DIFF
--- a/gast_to_code.py
+++ b/gast_to_code.py
@@ -16,10 +16,11 @@ def list_helper(gast_list, out_lang, btwn_str = ", "):
         
 
 def binOp_helper(gast, out_lang):
+    op = " " + str(gast["op"]) + " "
     left = gast_router(gast["left"], out_lang)
     right = gast_router(gast["right"], out_lang)
 
-    return left + gast["op"] + right
+    return left + op + right
 
 # py_specific_helpers
 def py_logStatement(gast):
@@ -29,6 +30,19 @@ def py_logStatement(gast):
 def py_varAssign(gast):
     value = gast_router(gast["varValue"], "py")
     return gast["varId"] + " = " + value
+
+def py_bool(gast):
+    if gast["value"] == 1:
+        return "True"
+    else:
+        return "False"
+
+def py_boolOp(gast):
+    op = " and " if gast["op"] == "&&" else " or "
+    left = gast_router(gast["left"], "py")
+    right = gast_router(gast["right"], "py")
+
+    return left + op + right
 
 # js_specific_helpers
 def js_logStatement(gast):
@@ -42,17 +56,14 @@ def js_varAssign(gast):
     
     return kind + " " + varId + " = " + varValue
 
-def py_bool(gast):
-    if gast["value"] == 1:
-        return "True"
-    else:
-        return "False"
-
 def js_bool(gast):
     if gast["value"] == 1:
         return "true"
     else:
         return "false"
+
+def js_boolOp(gast):
+    return binOp_helper(gast, "js")
 
 out = {
     "logStatement": {
@@ -66,6 +77,10 @@ out = {
     "bool": {
         "py": py_bool,
         "js": js_bool,
+    },
+    "boolOp": {
+        "py": py_boolOp,
+        "js": js_boolOp
     }
 }
 
@@ -100,4 +115,6 @@ def gast_router(gast, out_lang):
         return out["varAssign"][out_lang](gast)
     elif gast["type"] == "binOp":
         return binOp_helper(gast, out_lang)
+    elif gast["type"] == "boolOp":
+        return out["boolOp"][out_lang](gast)
 

--- a/gast_to_code.py
+++ b/gast_to_code.py
@@ -16,7 +16,6 @@ def list_helper(gast_list, out_lang, btwn_str = ", "):
         
 
 def binOp_helper(gast, out_lang):
-    op = " " + str(gast["op"]) + " "
     left = gast_router(gast["left"], out_lang)
     right = gast_router(gast["right"], out_lang)
 

--- a/gast_to_code.py
+++ b/gast_to_code.py
@@ -14,6 +14,14 @@ def list_helper(gast_list, out_lang, btwn_str = ", "):
     num_btwn_chars = len(btwn_str)
     return out[:-num_btwn_chars] # remove \nS
         
+
+def binOp_helper(gast, out_lang):
+    op = " " + str(gast["op"]) + " "
+    left = gast_router(gast["left"], out_lang)
+    right = gast_router(gast["right"], out_lang)
+
+    return left + gast["op"] + right
+
 # py_specific_helpers
 def py_logStatement(gast):
     arg_string = gast_router(gast["args"],"py")
@@ -84,14 +92,13 @@ def gast_router(gast, out_lang):
     elif gast["type"] == "bool":
         return out["bool"][out_lang](gast)
 
-    # commonly used
-
     #Other
     elif gast["type"] == "root":
         return list_helper(gast["body"], out_lang, "\n")
     elif gast["type"] == "logStatement":
         return out["logStatement"][out_lang](gast)
-
     elif gast["type"] == "varAssign":
         return out["varAssign"][out_lang](gast)
+    elif gast["type"] == "binOp":
+        return binOp_helper(gast, out_lang)
 

--- a/test_gast_to_code.py
+++ b/test_gast_to_code.py
@@ -168,7 +168,7 @@ class TestGastToCode(unittest2.TestCase):
         self.assertEqual('True or False and 4', gtc.gast_router(gast_boolOp_or_and, "py"))
 
     def test_boolOp_or_and_js (self):
-        self.assertEqual('True or False and 4', gtc.gast_router(gast_boolOp_or_and, "js"))
+        self.assertEqual('True || False && 4', gtc.gast_router(gast_boolOp_or_and, "js"))
 
     # test logStatement
     def test_js_logStatement_bool (self):

--- a/test_gast_to_code.py
+++ b/test_gast_to_code.py
@@ -34,9 +34,9 @@ gast_arr = {
 		]
 }
 
-gast_binOp_add = {'type': 'root', 'body': [{'type': 'binOp', 'op': '+', 'left': {'type': 'num', 'value': 3}, 'right': {'type': 'num', 'value': 4}}]}
+gast_binOp_add = {'type': 'binOp', 'op': '+', 'left': {'type': 'num', 'value': 3}, 'right': {'type': 'num', 'value': 4}}
 
-gast_binOp_add_sub_mult_div = {'type': 'root', 'body': [{'type': 'binOp', 'op': '-', 'left': {'type': 'binOp', 'op': '+', 'left': {'type': 'num', 'value': 1}, 'right': {'type': 'num', 'value': 2}}, 'right': {'type': 'binOp', 'op': '/', 'left': {'type': 'binOp', 'op': '*', 'left': {'type': 'num', 'value': 3}, 'right': {'type': 'num', 'value': 4}}, 'right': {'type': 'num', 'value': 5}}}]}
+gast_binOp_add_sub_mult_div = {'type': 'binOp', 'op': '-', 'left': {'type': 'binOp', 'op': '+', 'left': {'type': 'num', 'value': 1}, 'right': {'type': 'num', 'value': 2}}, 'right': {'type': 'binOp', 'op': '/', 'left': {'type': 'binOp', 'op': '*', 'left': {'type': 'num', 'value': 3}, 'right': {'type': 'num', 'value': 4}}, 'right': {'type': 'num', 'value': 5}}}
 
 gast_logStatement_bool = {
             "type": "root",
@@ -145,7 +145,7 @@ class TestGastToCode(unittest2.TestCase):
         self.assertEqual('3+4', gtc.gast_router(gast_binOp_add, "js"))
 
     def test_binOp_add_sub_mult_divb (self):
-        self.assertEqual('1 +2-3*4/5', gtc.gast_router(gast_binOp_add_sub_mult_div, "py"))
+        self.assertEqual('1+2-3*4/5', gtc.gast_router(gast_binOp_add_sub_mult_div, "py"))
         self.assertEqual('1+2-3*4/5', gtc.gast_router(gast_binOp_add_sub_mult_div, "js"))
 
     # test logStatement

--- a/test_gast_to_code.py
+++ b/test_gast_to_code.py
@@ -40,6 +40,10 @@ gast_binOp_bitwise = {'type': 'binOp', 'op': '&', 'left': {'type': 'num', 'value
 
 gast_binOp_add_sub_mult_div = {'type': 'binOp', 'op': '-', 'left': {'type': 'binOp', 'op': '+', 'left': {'type': 'num', 'value': 1}, 'right': {'type': 'num', 'value': 2}}, 'right': {'type': 'binOp', 'op': '/', 'left': {'type': 'binOp', 'op': '*', 'left': {'type': 'num', 'value': 3}, 'right': {'type': 'num', 'value': 4}}, 'right': {'type': 'num', 'value': 5}}}
 
+gast_boolOp_and = {'type': 'boolOp', 'op': '&&', 'left': {'type': 'bool', 'value': 1}, 'right': {'type': 'bool', 'value': 0}}
+
+gast_boolOp_or_and = {'type': 'boolOp', 'op': '||', 'left': {'type': 'bool', 'value': 1}, 'right': {'type': 'boolOp', 'op': '&&', 'left': {'type': 'bool', 'value': 0}, 'right': {'type': 'num', 'value': 4}}}
+
 gast_logStatement_bool = {
             "type": "root",
             "body": [
@@ -150,9 +154,21 @@ class TestGastToCode(unittest2.TestCase):
         self.assertEqual('1&3', gtc.gast_router(gast_binOp_bitwise, "py"))
         self.assertEqual('1&3', gtc.gast_router(gast_binOp_bitwise, "js"))
 
-    def test_binOp_add_sub_mult_divb (self):
+    def test_binOp_add_sub_mult_div (self):
         self.assertEqual('1+2-3*4/5', gtc.gast_router(gast_binOp_add_sub_mult_div, "py"))
         self.assertEqual('1+2-3*4/5', gtc.gast_router(gast_binOp_add_sub_mult_div, "js"))
+
+    def test_boolOp_and_py (self):
+        self.assertEqual('True and False', gtc.gast_router(gast_boolOp_and, "py"))
+
+    def test_boolOp_and_js (self):
+        self.assertEqual('True && False', gtc.gast_router(gast_boolOp_and, "js"))
+
+    def test_boolOp_or_and_py (self):
+        self.assertEqual('True and False', gtc.gast_router(gast_boolOp_or_and, "py"))
+
+    def test_boolOp_or_and_js (self):
+        self.assertEqual('True && False', gtc.gast_router(gast_boolOp_or_and, "js"))
 
     # test logStatement
     def test_js_logStatement_bool (self):

--- a/test_gast_to_code.py
+++ b/test_gast_to_code.py
@@ -34,6 +34,8 @@ gast_arr = {
 		]
 }
 
+gast_binOp = {'type': 'root', 'body': [{'type': 'binOp', 'op': '+', 'left': {'type': 'num', 'value': 3}, 'right': {'type': 'num', 'value': 4}}]}
+
 gast_logStatement_bool = {
             "type": "root",
             "body": [
@@ -136,6 +138,9 @@ class TestGastToCode(unittest2.TestCase):
         self.assertEqual('["hello", [1, 2]]', gtc.gast_router(gast_arr, "py"))
         self.assertEqual('["hello", [1, 2]]', gtc.gast_router(gast_arr, "js"))
 
+    def test_binOp (self):
+        self.assertEqual('3+4', gtc.gast_router(gast_binOp, "py"))
+        self.assertEqual('3+4', gtc.gast_router(gast_binOp, "js"))
 
     # test logStatement
     def test_js_logStatement_bool (self):

--- a/test_gast_to_code.py
+++ b/test_gast_to_code.py
@@ -165,10 +165,10 @@ class TestGastToCode(unittest2.TestCase):
         self.assertEqual('True && False', gtc.gast_router(gast_boolOp_and, "js"))
 
     def test_boolOp_or_and_py (self):
-        self.assertEqual('True and False', gtc.gast_router(gast_boolOp_or_and, "py"))
+        self.assertEqual('True or False and 4', gtc.gast_router(gast_boolOp_or_and, "py"))
 
     def test_boolOp_or_and_js (self):
-        self.assertEqual('True && False', gtc.gast_router(gast_boolOp_or_and, "js"))
+        self.assertEqual('True or False and 4', gtc.gast_router(gast_boolOp_or_and, "js"))
 
     # test logStatement
     def test_js_logStatement_bool (self):

--- a/test_gast_to_code.py
+++ b/test_gast_to_code.py
@@ -34,7 +34,9 @@ gast_arr = {
 		]
 }
 
-gast_binOp = {'type': 'root', 'body': [{'type': 'binOp', 'op': '+', 'left': {'type': 'num', 'value': 3}, 'right': {'type': 'num', 'value': 4}}]}
+gast_binOp_add = {'type': 'root', 'body': [{'type': 'binOp', 'op': '+', 'left': {'type': 'num', 'value': 3}, 'right': {'type': 'num', 'value': 4}}]}
+
+gast_binOp_add_sub_mult_div = {'type': 'root', 'body': [{'type': 'binOp', 'op': '-', 'left': {'type': 'binOp', 'op': '+', 'left': {'type': 'num', 'value': 1}, 'right': {'type': 'num', 'value': 2}}, 'right': {'type': 'binOp', 'op': '/', 'left': {'type': 'binOp', 'op': '*', 'left': {'type': 'num', 'value': 3}, 'right': {'type': 'num', 'value': 4}}, 'right': {'type': 'num', 'value': 5}}}]}
 
 gast_logStatement_bool = {
             "type": "root",
@@ -138,9 +140,13 @@ class TestGastToCode(unittest2.TestCase):
         self.assertEqual('["hello", [1, 2]]', gtc.gast_router(gast_arr, "py"))
         self.assertEqual('["hello", [1, 2]]', gtc.gast_router(gast_arr, "js"))
 
-    def test_binOp (self):
-        self.assertEqual('3+4', gtc.gast_router(gast_binOp, "py"))
-        self.assertEqual('3+4', gtc.gast_router(gast_binOp, "js"))
+    def test_binOp_add (self):
+        self.assertEqual('3+4', gtc.gast_router(gast_binOp_add, "py"))
+        self.assertEqual('3+4', gtc.gast_router(gast_binOp_add, "js"))
+
+    def test_binOp_add_sub_mult_divb (self):
+        self.assertEqual('1 +2-3*4/5', gtc.gast_router(gast_binOp_add_sub_mult_div, "py"))
+        self.assertEqual('1+2-3*4/5', gtc.gast_router(gast_binOp_add_sub_mult_div, "js"))
 
     # test logStatement
     def test_js_logStatement_bool (self):

--- a/test_gast_to_code.py
+++ b/test_gast_to_code.py
@@ -147,28 +147,28 @@ class TestGastToCode(unittest2.TestCase):
         self.assertEqual('["hello", [1, 2]]', gtc.gast_router(gast_arr, "js"))
 
     def test_binOp_add (self):
-        self.assertEqual('3+4', gtc.gast_router(gast_binOp_add, "py"))
-        self.assertEqual('3+4', gtc.gast_router(gast_binOp_add, "js"))
+        self.assertEqual('3 + 4', gtc.gast_router(gast_binOp_add, "py"))
+        self.assertEqual('3 + 4', gtc.gast_router(gast_binOp_add, "js"))
 
     def test_binOp_bitwise (self):
-        self.assertEqual('1&3', gtc.gast_router(gast_binOp_bitwise, "py"))
-        self.assertEqual('1&3', gtc.gast_router(gast_binOp_bitwise, "js"))
+        self.assertEqual('1 & 3', gtc.gast_router(gast_binOp_bitwise, "py"))
+        self.assertEqual('1 & 3', gtc.gast_router(gast_binOp_bitwise, "js"))
 
     def test_binOp_add_sub_mult_div (self):
-        self.assertEqual('1+2-3*4/5', gtc.gast_router(gast_binOp_add_sub_mult_div, "py"))
-        self.assertEqual('1+2-3*4/5', gtc.gast_router(gast_binOp_add_sub_mult_div, "js"))
+        self.assertEqual('1 + 2 - 3 * 4 / 5', gtc.gast_router(gast_binOp_add_sub_mult_div, "py"))
+        self.assertEqual('1 + 2 - 3 * 4 / 5', gtc.gast_router(gast_binOp_add_sub_mult_div, "js"))
 
     def test_boolOp_and_py (self):
         self.assertEqual('True and False', gtc.gast_router(gast_boolOp_and, "py"))
 
     def test_boolOp_and_js (self):
-        self.assertEqual('True && False', gtc.gast_router(gast_boolOp_and, "js"))
+        self.assertEqual('true && false', gtc.gast_router(gast_boolOp_and, "js"))
 
     def test_boolOp_or_and_py (self):
         self.assertEqual('True or False and 4', gtc.gast_router(gast_boolOp_or_and, "py"))
 
     def test_boolOp_or_and_js (self):
-        self.assertEqual('True || False && 4', gtc.gast_router(gast_boolOp_or_and, "js"))
+        self.assertEqual('true || false && 4', gtc.gast_router(gast_boolOp_or_and, "js"))
 
     # test logStatement
     def test_js_logStatement_bool (self):

--- a/test_gast_to_code.py
+++ b/test_gast_to_code.py
@@ -36,6 +36,8 @@ gast_arr = {
 
 gast_binOp_add = {'type': 'binOp', 'op': '+', 'left': {'type': 'num', 'value': 3}, 'right': {'type': 'num', 'value': 4}}
 
+gast_binOp_bitwise = {'type': 'binOp', 'op': '&', 'left': {'type': 'num', 'value': 1}, 'right': {'type': 'num', 'value': 3}}
+
 gast_binOp_add_sub_mult_div = {'type': 'binOp', 'op': '-', 'left': {'type': 'binOp', 'op': '+', 'left': {'type': 'num', 'value': 1}, 'right': {'type': 'num', 'value': 2}}, 'right': {'type': 'binOp', 'op': '/', 'left': {'type': 'binOp', 'op': '*', 'left': {'type': 'num', 'value': 3}, 'right': {'type': 'num', 'value': 4}}, 'right': {'type': 'num', 'value': 5}}}
 
 gast_logStatement_bool = {
@@ -143,6 +145,10 @@ class TestGastToCode(unittest2.TestCase):
     def test_binOp_add (self):
         self.assertEqual('3+4', gtc.gast_router(gast_binOp_add, "py"))
         self.assertEqual('3+4', gtc.gast_router(gast_binOp_add, "js"))
+
+    def test_binOp_bitwise (self):
+        self.assertEqual('1&3', gtc.gast_router(gast_binOp_bitwise, "py"))
+        self.assertEqual('1&3', gtc.gast_router(gast_binOp_bitwise, "js"))
 
     def test_binOp_add_sub_mult_divb (self):
         self.assertEqual('1+2-3*4/5', gtc.gast_router(gast_binOp_add_sub_mult_div, "py"))


### PR DESCRIPTION
Using the new way that we work with types, enabled gast_to_code for binary and boolean operations. Now can translate from gast to code for these types of operations.

Also wrote tests along side them.