### PR TITLE
Add unsupported type to GAST. GAST to code prints unsupported message

### DIFF
--- a/gast_to_code.py
+++ b/gast_to_code.py
@@ -195,6 +195,11 @@ def gast_router(gast, out_lang):
         return binOp_helper(gast, out_lang)
     elif gast["type"] == "boolOp":
         return out["boolOp"][out_lang](gast)
+    elif gast["type"] == "error":
+        if gast["value"] == "unsupported":
+            # Error string
+            return "Feature not supported"
+        return "Error"
 
 
 

--- a/translate/routers/js_router.py
+++ b/translate/routers/js_router.py
@@ -56,8 +56,7 @@ def node_to_gast(node):
         return js_conditional.if_statement(node)
     else:
         # not supported
-        print(node.type)
-        return "No match"
+        return {"type": "error", "value": "unsupported"}
 
 
 

--- a/translate/routers/py_router.py
+++ b/translate/routers/py_router.py
@@ -49,5 +49,4 @@ def node_to_gast(node):
 
 
     else:
-        print("nothing hit")
-        return "nothing hit"
+        return {"type": "error", "value": "unsupported"}


### PR DESCRIPTION
GAST adds node with type:error if feature is not supported. In code to gast output code is filled with error message.  