### PR TITLE
Comparators

### DIFF
--- a/code_to_gast/helpers/py_helpers.py
+++ b/code_to_gast/helpers/py_helpers.py
@@ -162,6 +162,9 @@ def unary_op_to_gast(node):
 
 """
 takes node of type Compare and converts it to our generic ast representation
+example:
+    Example In: Compare(left=Num(n=1), ops=[Gt()], comparators=[Num(n=1), Num(n=2)])
+    Example Out: {'type': 'binOp', 'left': {'type': 'num', 'value': 1}, 'op': '>', 'right': {'type': 'num', 'value': 2}}
 """
 def compare_to_gast(node):
     # create list of comparators. (1>2>=3 would create list [1,2,3])

--- a/code_to_gast/helpers/py_helpers.py
+++ b/code_to_gast/helpers/py_helpers.py
@@ -173,6 +173,7 @@ def compare_to_gast(node):
 
     return compare_helper(comparator_list, op_list)
 
+# TODO: combine logic in bool_op_helper and compare_helper into single function
 def compare_helper(node_list, op_list):
     gast = {}
     gast["type"] = "binOp"

--- a/code_to_gast/helpers/py_helpers.py
+++ b/code_to_gast/helpers/py_helpers.py
@@ -68,12 +68,19 @@ def pyop_to_str(op):
         ast.BitOr: "|", 
         ast.And: "&&", 
         ast.Or: "||",
-        ast.Not: "!"
+        ast.Not: "!",
+        ast.Gt: ">",
+        ast.GtE: ">=",
+        ast.Lt: "<",
+        ast.LtE: "<=",
+        ast.Eq: "=="
+
     }
     return op_to_str_map[type(op)]
 
 
 """
+TODO: fix this docstring
 converts a python ast BoolOp into a readable string recursively
 example: True and False
     exampleIn: BoolOp(op=And(), values=[NameConstant(value=True), NameConstant(value=False)])
@@ -152,3 +159,29 @@ takes node of type unaryOp and converts it to our generic ast represenations
 """
 def unary_op_to_gast(node):
     return {"type": "unaryOp", "op": pyop_to_str(node.op), "arg": pr.node_to_gast(node.operand)}
+
+"""
+takes node of type Compare and converts it to our generic ast representation
+"""
+def compare_to_gast(node):
+    # create list of comparators. (1>2>=3 would create list [1,2,3])
+    comparator_list = node.comparators
+    comparator_list.insert(0, node.left) # this is necessary since pyAST stores leftmost comparator seperately
+
+    # create list of operators. (1>2>=3 would create list [>, >=]
+    op_list = node.ops
+
+    return compare_helper(comparator_list, op_list)
+
+def compare_helper(node_list, op_list):
+    gast = {}
+    gast["type"] = "binOp"
+    gast["left"] = pr.node_to_gast(node_list[0])
+    gast["op"] = pyop_to_str(op_list[0])
+
+    if len(node_list[1:]) > 1:
+        gast["right"] = compare_helper(node_list[1:], op_list[1:])
+    else:
+        gast["right"] = pr.node_to_gast(node_list[1])
+
+    return gast

--- a/code_to_gast/routers/py_router.py
+++ b/code_to_gast/routers/py_router.py
@@ -32,6 +32,8 @@ def node_to_gast(node):
         return helpers.name_to_gast(node)
     elif type(node) == ast.UnaryOp:
         return helpers.unary_op_to_gast(node)
+    elif type(node) == ast.Compare:
+        return helpers.compare_to_gast(node)
 
     # Expressions
     elif type(node) == ast.Expr:

--- a/test/test_bin_bool_ops.py
+++ b/test/test_bin_bool_ops.py
@@ -73,14 +73,22 @@ class TestBinBoolOps(unittest2.TestCase):
         py_code = '1 > 2'
         self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
         self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+
     def test_compare_less_than_or_equal(self):
         js_code = '1 <= 2'
         py_code = '1 <= 2'
         self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
         self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        
     def test_compare_equal(self):
         js_code = '1 == 2'
         py_code = '1 == 2'
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+
+    def test_comparemulti_equal(self):
+        js_code = '1 == 2 == 3'
+        py_code = '1 == 2 == 3'
         self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
         self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
 

--- a/test/test_bin_bool_ops.py
+++ b/test/test_bin_bool_ops.py
@@ -5,6 +5,7 @@ import unittest2
 import main
 
 class TestBinBoolOps(unittest2.TestCase):
+    #TODO: add whitespace to methods
     def test_bin_no_nesting(self):
         js_code = '1 + 2'
         py_code = '1 + 2'
@@ -66,5 +67,22 @@ class TestBinBoolOps(unittest2.TestCase):
         py_code = '1 or 2 and 3 or 4 + 3'
         self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
         self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+
+    def test_compare_greater_than(self):
+        js_code = '1 > 2'
+        py_code = '1 > 2'
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+    def test_compare_less_than_or_equal(self):
+        js_code = '1 <= 2'
+        py_code = '1 <= 2'
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+    def test_compare_equal(self):
+        js_code = '1 == 2'
+        py_code = '1 == 2'
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+
 if __name__ == '__main__':
     unittest2.main()

--- a/test/test_bin_bool_ops.py
+++ b/test/test_bin_bool_ops.py
@@ -92,5 +92,17 @@ class TestBinBoolOps(unittest2.TestCase):
         self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
         self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
 
+    def test_comparemulti_all_ops (self):
+        js_code = '1 < 2 <= 3 == 4 >= 5 > 6'
+        py_code = '1 < 2 <= 3 == 4 >= 5 > 6'
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+
+    def test_comparemulti_strs (self):
+        js_code = 'a > b >= c == C'
+        py_code = 'a > b >= c == C'
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+
 if __name__ == '__main__':
     unittest2.main()


### PR DESCRIPTION
We decided to represent comparators (i.e. 1 > 2) in the gast as binary operations, similar to how javascript does it. Due to the recursion, javascript to python was already working for comparators. However, since python implements comparators very differently, I had to do some work to convert the py ast to gast.

Also wrote test cases for comparators to check if things break in the future.