### PR TITLE
Add and make accessible more information about each converter 

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ class Translate(Resource):
         # Gets non-beta (fully supported) languages for automatic detection
         fully_supported_lang_codes = ConverterRegistry.get_fully_supported_language_codes()
 
-        # automatic language detection (only fully supported languages)
+        # automatic language detection (only fully supported languages) TODO: fall back on Beta if all else fails
         i = 0
         while (output_code == "Error: did not compile") and (i < len(fully_supported_lang_codes)):
             response_input_lang = fully_supported_lang_codes[i]

--- a/app.py
+++ b/app.py
@@ -17,8 +17,7 @@ parser.add_argument('out_lang')
 
 class Translate(Resource):
     def __init__(self):
-        self.lang_codes = ConverterRegistry.get_language_codes()
-        self.lang_object = ConverterRegistry.get_pretty_names()
+        self.lang_object = ConverterRegistry.get_lang_dict()
 
     def get(self):
         return {'supported_languages': self.lang_object}
@@ -33,10 +32,13 @@ class Translate(Resource):
         output_code = main(input_code, input_lang, output_lang)
         response_input_lang = input_lang
 
-        # automatic language detection
+        # Gets non-beta (alpha) languages for automatic detection
+        alpha_lang_codes = ConverterRegistry.get_alpha_language_codes()
+
+        # automatic language detection (only alpha languages)
         i = 0
-        while (output_code == "Error: did not compile") and (i < len(self.lang_codes)):
-            response_input_lang = self.lang_codes[i]
+        while (output_code == "Error: did not compile") and (i < len(alpha_lang_codes)):
+            response_input_lang = alpha_lang_codes[i]
             output_code = main(input_code, response_input_lang, output_lang)
             i += 1
 

--- a/app.py
+++ b/app.py
@@ -32,13 +32,13 @@ class Translate(Resource):
         output_code = main(input_code, input_lang, output_lang)
         response_input_lang = input_lang
 
-        # Gets non-beta (alpha) languages for automatic detection
-        alpha_lang_codes = ConverterRegistry.get_alpha_language_codes()
+        # Gets non-beta (fully supported) languages for automatic detection
+        fully_supported_lang_codes = ConverterRegistry.get_fully_supported_language_codes()
 
-        # automatic language detection (only alpha languages)
+        # automatic language detection (only fully supported languages)
         i = 0
-        while (output_code == "Error: did not compile") and (i < len(alpha_lang_codes)):
-            response_input_lang = alpha_lang_codes[i]
+        while (output_code == "Error: did not compile") and (i < len(fully_supported_lang_codes)):
+            response_input_lang = fully_supported_lang_codes[i]
             output_code = main(input_code, response_input_lang, output_lang)
             i += 1
 

--- a/bash/gast_to_code/bash_gast_to_code_converter.py
+++ b/bash/gast_to_code/bash_gast_to_code_converter.py
@@ -4,7 +4,10 @@ import shared.gast_to_code.gast_to_code_router as router
 
 
 class BashGastToCodeConverter(AbstractGastToCodeConverter):
-    pretty_name = "Bash"
+    name = "Bash"
+    is_beta = True
+    is_input_lang = False
+    is_output_lang = True
    
     def handle_bool(gast):
         return "Bash does not support booleans"

--- a/java/gast_to_code/gast_to_code_java.py
+++ b/java/gast_to_code/gast_to_code_java.py
@@ -2,7 +2,10 @@ import shared.gast_to_code.gast_to_code_router as router
 from shared.gast_to_code.abstract_gast_to_code_converter import AbstractGastToCodeConverter
 
 class JavaGastToCodeConverter(AbstractGastToCodeConverter):
-    pretty_name = "Java"
+    name = "Java"
+    is_beta = True
+    is_input_lang = True
+    is_output_lang = True
 
     def handle_bool(gast):
         if gast["value"] == 1:

--- a/javascript/gast_to_code/js_gast_to_code_converter.py
+++ b/javascript/gast_to_code/js_gast_to_code_converter.py
@@ -5,7 +5,10 @@ import shared.gast_to_code.gast_to_code_router as router
 
 
 class JsGastToCodeConverter(AbstractGastToCodeConverter):
-    pretty_name = "Javascript"
+    name = "Javascript"
+    is_beta = False
+    is_input_lang = True
+    is_output_lang = True
 
     def handle_bool(gast):
         if gast["value"] == 1:

--- a/python/gast_to_code/py_gast_to_code_converter.py
+++ b/python/gast_to_code/py_gast_to_code_converter.py
@@ -4,7 +4,10 @@ import shared.gast_to_code.general_helpers as general_helpers
 import py_built_in_functions
 
 class PyGastToCodeConverter(AbstractGastToCodeConverter):
-    pretty_name = "Python"
+    name = "Python"
+    is_beta = False
+    is_input_lang = True
+    is_output_lang = True
 
     def handle_bool(gast):
         if gast["value"] == 1:

--- a/shared/gast_to_code/converter_registry.py
+++ b/shared/gast_to_code/converter_registry.py
@@ -11,24 +11,41 @@ class ConverterRegistry():
         return ConverterRegistry.converters[lang_code]
     
     """
-    Returns supported language codes in the converter as a list of strings
+    Returns supported language codes in the converter as a list of strings.
+    Only returns language codes where is_beta is false
     """
     @staticmethod
-    def get_language_codes():
-        return list(ConverterRegistry.converters.keys())
-
-    """
-    Returns a dictionary where keys are language codes and values are
-    pretty language names
-    """
-    @staticmethod
-    def get_pretty_names():
-        pretty_names_dict = {}
+    def get_alpha_language_codes():
+        alpha_language_codes = []
         for lang_code in ConverterRegistry.converters.keys():
             converter = ConverterRegistry.get_converter(lang_code)
-            pretty_names_dict[lang_code] = converter.pretty_name
+            
+            if not converter.is_beta:
+                alpha_language_codes.append(lang_code)
 
-        return pretty_names_dict
+        return alpha_language_codes
+
+    """
+    Returns a dictionary where keys are language codes are dicts
+    with pretty names, and booleans indicating information about whether 
+    the language is in beta, supports input and supports output
+    """
+    @staticmethod
+    def get_lang_dict():
+        lang_dict = {}
+        for lang_code in ConverterRegistry.converters.keys():
+            converter = ConverterRegistry.get_converter(lang_code)
+
+            lang_specific_dict = {
+                "name": converter.name,
+                "is_beta": converter.is_beta,
+                "is_input_lang": converter.is_input_lang,
+                "is_output_lang": converter.is_output_lang
+            }
+
+            lang_dict[lang_code] = lang_specific_dict
+
+        return lang_dict
 
 
 

--- a/shared/gast_to_code/converter_registry.py
+++ b/shared/gast_to_code/converter_registry.py
@@ -15,15 +15,15 @@ class ConverterRegistry():
     Only returns language codes where is_beta is false
     """
     @staticmethod
-    def get_alpha_language_codes():
-        alpha_language_codes = []
+    def get_fully_supported_language_codes():
+        fully_supported_language_codes = []
         for lang_code in ConverterRegistry.converters.keys():
             converter = ConverterRegistry.get_converter(lang_code)
             
             if not converter.is_beta:
-                alpha_language_codes.append(lang_code)
+                fully_supported_language_codes.append(lang_code)
 
-        return alpha_language_codes
+        return fully_supported_language_codes
 
     """
     Returns a dictionary where keys are language codes are dicts


### PR DESCRIPTION
Realized that the presence of beta languages in auto-detect was creating issues. We already had a [ticket](https://tree.taiga.io/project/jackdavidweber-cjs-capstone/us/142?no-milestone=1) for adding more information to the converters. This information could then be used to block beta languages from being used in auto-detect. The information was also supplied into the Get request

### GET Request Before ([PR](https://github.com/jackdavidweber/cjs_capstone/pull/81))
![image](https://user-images.githubusercontent.com/19896216/87689602-4737e780-c73d-11ea-8697-f32744829738.png)

### GET Request After
![image](https://user-images.githubusercontent.com/19896216/87837647-147b1580-c849-11ea-850c-ec6736be8162.png)
