### PR TITLE
Support to use range function with one arg

### DIFF
--- a/python/code_to_gast/py_loop.py
+++ b/python/code_to_gast/py_loop.py
@@ -41,9 +41,14 @@ def for_range_statement_to_gast(node):
         gast["type"] = "forRangeStatement"
         ast.dump(node)
         args = node.iter.args
-        step_num = get_step_num(args)
-        start_num = arg_node_to_num(args[0])
-        end_num = arg_node_to_num(args[1])
+        if len(args) == 1:
+            step_num = 1
+            start_num = 0
+            end_num = arg_node_to_num(args[0])
+        else:
+            step_num = get_step_num(args)
+            start_num = arg_node_to_num(args[0])
+            end_num = arg_node_to_num(args[1])
 
         gast["init"] = for_range_statement_init_helper(node.target, start_num)
         gast["test"] = for_range_statement_test_helper(node.target, start_num, end_num)

--- a/python/code_to_gast/py_loop.py
+++ b/python/code_to_gast/py_loop.py
@@ -41,14 +41,9 @@ def for_range_statement_to_gast(node):
         gast["type"] = "forRangeStatement"
         ast.dump(node)
         args = node.iter.args
-        if len(args) == 1:
-            step_num = 1
-            start_num = 0
-            end_num = arg_node_to_num(args[0])
-        else:
-            step_num = get_step_num(args)
-            start_num = arg_node_to_num(args[0])
-            end_num = arg_node_to_num(args[1])
+        start_num = get_start_num(args)
+        end_num = get_end_num(args)
+        step_num = get_step_num(args)
 
         gast["init"] = for_range_statement_init_helper(node.target, start_num)
         gast["test"] = for_range_statement_test_helper(node.target, start_num, end_num)
@@ -138,10 +133,33 @@ def get_step_num(args):
     elif len(args) == 2:
         step_num = 1
 
+    elif len(args) == 1:
+        step_num = 1
+
     else:
         return {"type": "error", "value": "unsupported number of arguments"}
 
     return step_num
+
+def get_start_num(args):
+    if len(args) == 3 or len(args) == 2:
+        return arg_node_to_num(args[0])
+    
+    elif len(args) == 1:
+        return 0
+    
+    else:
+        return {"type": "error", "value": "unsupported number of arguments"}
+
+def get_end_num(args):
+    if len(args) == 3 or len(args) == 2:
+        return arg_node_to_num(args[1])
+    
+    elif len(args) == 1:
+        return arg_node_to_num(args[0])
+    
+    else:
+        return {"type": "error", "value": "unsupported number of arguments"}
 
 """
 python stores argument nodes as ast.UnaryOp for negative numbers and

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -56,6 +56,15 @@ class TestLoops(unittest2.TestCase):
         self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
         self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
 
+    def test_for_range_one_arg_loop(self):
+        ''' 
+        users can give range 1 args - translations give range 3 args 
+        hence js -> py is not supported for this translation 
+        '''
+        js_code = 'for (let i = 0; i < 5; i += 1) {\n\tconsole.log(i)\n}'
+        py_code = 'for i in range (5):\n\tprint(i)'
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+
 
 if __name__ == '__main__':
     unittest2.main()


### PR DESCRIPTION
Support functionality of one argument loops in python to translate to other languages. 
```
for i in range(4):
    print(i)
```
Note: translations of loops TO python still use a 3 argument range function 