### PR TITLE
Handling Errors: Prevent "internal server errors" by using Try/Catch

### DIFF
--- a/java/code_to_gast/java_main.py
+++ b/java/code_to_gast/java_main.py
@@ -5,12 +5,18 @@ import java.code_to_gast.java_router as java_router
 takes js string and converts it to a generic AST
 """
 def java_to_gast(java_input):
-    # wrap input code in a class and function
-    class_wrapper = '''
-    class Test {{
-        public static void main(String[] args) {{
-            {java_input}
-        }}
-    }}'''.format(java_input = java_input)
-    input_ast = javalang.parse.parse(class_wrapper)
+    input_ast = ''
+
+    try:
+        # wrap input code in a class and function
+        class_wrapper = '''
+        class Test {{
+            public static void main(String[] args) {{
+                {java_input}
+            }}
+        }}'''.format(java_input = java_input)
+        input_ast = javalang.parse.parse(class_wrapper)
+    except:
+        "Error: code could not compile"
+    
     return java_router.node_to_gast(input_ast)

--- a/main.py
+++ b/main.py
@@ -15,41 +15,77 @@ output_lang: string representing output language of code
 return: string representing output code or error message
 """
 def main(input_code, input_lang, output_lang):
+    try:
+        # check arguments TODO(taiga#172): remove hard coded references
+        check_valid_args(input_code, input_lang, output_lang, ["js", "py", "java"], ["js", "py", "bash", "java"])
 
-    if input_lang == None and output_lang == None:
-        abort(400, "Error: must specify input and output languages")
+        # code to gast
+        gast = main_code_to_gast(input_code, input_lang)
+        check_valid_gast(gast)
 
-    if input_lang == "js":
-        gast = js_main.js_to_gast(input_code)
-    elif input_lang == "py":
-        gast = py_main.py_to_gast(input_code)
-    elif input_lang == "java":
-        gast = java_main.java_to_gast(input_code)
-    else:
-        #TODO: figure out hwo to do error messages
-        return "Error must specify input language. For example, js for javascript and py for python"
+        #gast to code
+        output_code = main_gast_to_code(gast, output_lang)
 
-    output_langs = ["js", "py", "bash", "java"]
-    if output_lang not in output_langs:
-        # TODO: send 400 client error
-        return "Error must specify output language. For example, js for javascript and py for python"
+        # analytics
+        main_analytics(input_code, output_code, input_lang, output_lang)
+
+        return output_code
+    except:
+        # This error should never occur but probably a good thing to have in case
+        return "Error: unable to execute main function"
+
+
+def main_code_to_gast(input_code, input_lang):
+    try:
+        # TODO(taiga#172): remove hard coded references
+        if input_lang == "js":
+            gast = js_main.js_to_gast(input_code)
+        elif input_lang == "py":
+            gast = py_main.py_to_gast(input_code)
+        elif input_lang == "java":
+            gast = java_main.java_to_gast(input_code)
+        else:
+            return "Error must specify input language. For example, js for javascript and py for python"
+
+        return gast
+    except:
+        return "Error: unable to convert code to generic ast"
+
+
+def check_valid_args(input_code, input_lang, output_lang, valid_input_langs, valid_output_langs):
+    if not (type(input_code) == str and type(input_lang) == str and type(output_lang) == str):
+        abort(400, "Error: invalid argument types")
+
+    if input_lang not in valid_input_langs:
+        abort(400, "Error must specify valid input language. For example, js for javascript and py for python")
    
-    output_code = ""
-    if (type(gast) == str) :
-        # return error if gast not built - dont store in database
-        output_code = "Error: did not compile"
-    else:
-        output_code = gtc.gast_to_code(gast, output_lang)
+    if output_lang not in valid_output_langs:
+        abort(400, "Error must specify valid output language. For example, js for javascript and py for python")
+   
 
+def check_valid_gast(gast):
+    if (type(gast) == str) : # FIXME(swalsh15) why is this necessary??
+        # return error if gast not built - dont store in database
+        abort(400, "Error: did not compile")
+
+
+def main_gast_to_code(gast, output_lang):
+    try:
+        output_code = gtc.gast_to_code(gast, output_lang)
+        
         if output_lang == "java":
             output_code = general_helpers.java_linter(output_code)
-    
+
+        return output_code
+    except:
+        return "Error: unable to convert generic ast to code"
+
+
+def main_analytics(input_code, output_code, input_lang, output_lang):
     # if the user deletes their translation don't store empty translation "" -> ""
     if (input_code == "" and output_code == ""):
-        return output_code
-    
-    # store translation on firebase
-    data_service = DataService.getInstance()
-    data_service.store_query(input_code, output_code, input_lang, output_lang)
-
-    return output_code
+        pass
+    else:
+        # store translation on firebase
+        data_service = DataService.getInstance()
+        data_service.store_query(input_code, output_code, input_lang, output_lang)

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def main(input_code, input_lang, output_lang):
         output_code = main_gast_to_code(gast, output_lang)
 
         # analytics
-        main_analytics(input_code, output_code, input_lang, output_lang)
+        main_store_analytics(input_code, output_code, input_lang, output_lang)
 
         return output_code
     except:
@@ -81,7 +81,7 @@ def main_gast_to_code(gast, output_lang):
         return "Error: unable to convert generic ast to code"
 
 
-def main_analytics(input_code, output_code, input_lang, output_lang):
+def main_store_analytics(input_code, output_code, input_lang, output_lang):
     # if the user deletes their translation don't store empty translation "" -> ""
     if (input_code == "" and output_code == ""):
         pass

--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ import shared.gast_to_code.general_helpers as general_helpers
 from data_service import DataService
 from bootstrap import bootstrap
 import subprocess
-import json
 
 """
 input_code: string representing input code
@@ -26,8 +25,6 @@ def main(input_code, input_lang, output_lang):
         gast = py_main.py_to_gast(input_code)
     elif input_lang == "java":
         gast = java_main.java_to_gast(input_code)
-    elif input_lang == "bash":
-        gast = run_bash_javascript(input_code)
     else:
         #TODO: figure out hwo to do error messages
         return "Error must specify input language. For example, js for javascript and py for python"
@@ -56,14 +53,3 @@ def main(input_code, input_lang, output_lang):
     data_service.store_query(input_code, output_code, input_lang, output_lang)
 
     return output_code
-
-"""
-Uses subprocess library to read from sdout after running javascript code
-"""
-def run_bash_javascript(input_code):
-        process = subprocess.Popen(['node', 'bash/code_to_gast/bash_main.js', input_code], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, error = process.communicate()
-        string_output = out.decode('utf-8')
-        return json.loads(string_output)
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ six==1.15.0
 Werkzeug==1.0.1
 firebase-admin==4.3.0
 javalang==0.13.0
-bashlex==0.15


### PR DESCRIPTION
Certain translations were causing the backend to send an "internal server error" to the frontend which looked pretty bad.

![image](https://user-images.githubusercontent.com/19896216/87982478-b5f1a980-ca8b-11ea-94ca-f44f0c70ff2c.png)
This PR attempts to capture nearly all possible errors using try/except and abort(). In the process, I also refactor main.py to make it more readable and easier to add error checking.

**NOTE:** the actual error messages that are returned should be considered temporary as they will shortly be [replaced by error objects](https://tree.taiga.io/project/jackdavidweber-cjs-capstone/us/166?no-milestone=1) as described in the [handling errors doc.](https://docs.google.com/document/d/1wccE4ECuD0vac6efbEdOXfkkDQD23zBN8bX1WyT4V30/edit?usp=sharing)
### Before

* `curl http://127.0.0.1:5000/ -d "input=5&in_lang=java&out_lang=py"`
    * `Traceback (most recent call last): File ....`
* `curl http://127.0.0.1:5000/ -d "input=for (i=0; i<10; i++){}&in_lang=js&out_lang=py"`
    * `Traceback (most recent call last): File ....`
### After
* `curl http://127.0.0.1:5000/ -d "input=5&in_lang=java&out_lang=py"`
    * `Feature not supported`
* `curl http://127.0.0.1:5000/ -d "input=for (i=0; i<10; i++){}&in_lang=js&out_lang=py"`
    * `Error: unable to convert generic ast to code`