### PR TITLE
Handling errors refactor

### DIFF
--- a/debug.py
+++ b/debug.py
@@ -1,3 +1,7 @@
-import bash.code_to_gast.bash_main as bash_main
+import main
+from bootstrap import bootstrap
 
-print(bash_main.bash_to_gast('true'))
+# Register all languages before testing can begin
+bootstrap()
+
+print(main.main('print(1)', 'py', 'js'))

--- a/javascript/gast_to_code/js_gast_to_code_converter.py
+++ b/javascript/gast_to_code/js_gast_to_code_converter.py
@@ -9,6 +9,14 @@ class JsGastToCodeConverter(AbstractGastToCodeConverter):
     is_beta = False
     is_input_lang = True
     is_output_lang = True
+    response = {
+        "input": None,
+        "translation": None,
+        "error": None
+    }
+
+    def get_response():
+        return
 
     def handle_bool(gast):
         if gast["value"] == 1:

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import python.code_to_gast.py_main as py_main
 import java.code_to_gast.java_main as java_main
 import shared.gast_to_code.gast_to_code_router as gtc
 import shared.gast_to_code.general_helpers as general_helpers
+from shared.gast_to_code.converter_registry import ConverterRegistry
 from data_service import DataService
 from bootstrap import bootstrap
 import subprocess
@@ -16,25 +17,24 @@ return: string representing output code or error message
 
 
 def main(input_code, input_lang, output_lang):
-    try:
-        # check arguments TODO(taiga#172): remove hard coded references
-        check_valid_args(input_code, input_lang, output_lang,
-                         ["js", "py", "java"], ["js", "py", "bash", "java"])
+    # check arguments TODO(taiga#172): remove hard coded references
+    check_valid_args(input_code, input_lang, output_lang,
+                        ["js", "py", "java"], ["js", "py", "bash", "java"])
 
-        # code to gast
-        gast = main_code_to_gast(input_code, input_lang)
-        check_valid_gast(gast)
+    # code to gast
+    gast = main_code_to_gast(input_code, input_lang)
+    check_valid_gast(gast)
 
-        #gast to code
-        output_code = main_gast_to_code(gast, output_lang)
+    #gast to code
+    output_code = main_gast_to_code(gast, output_lang)
+    converter = ConverterRegistry.get_converter("js")
+    print(converter.set_response())
 
-        # analytics
-        main_store_analytics(input_code, output_code, input_lang, output_lang)
+    # analytics
+    main_store_analytics(input_code, output_code, input_lang, output_lang)
 
-        return output_code
-    except:
-        # This error should never occur but probably a good thing to have in case
-        return "Error: unable to execute main function"
+    return output_code
+
 
 
 def main_code_to_gast(input_code, input_lang):

--- a/shared/gast_to_code/abstract_gast_to_code_converter.py
+++ b/shared/gast_to_code/abstract_gast_to_code_converter.py
@@ -2,6 +2,9 @@ from abc import ABC, abstractmethod
 
 
 class AbstractGastToCodeConverter(ABC):
+    @abstractmethod
+    def get_response(self):
+        pass
 
     @abstractmethod
     def handle_log_statement(gast):

--- a/shared/gast_to_code/gast_to_code_router.py
+++ b/shared/gast_to_code/gast_to_code_router.py
@@ -15,7 +15,7 @@ def gast_to_code(gast, out_lang, lvl=0):
 
     if type(gast) == list:
         # bash has no comma between function arguments
-        if out_lang == "bash":
+        if out_lang == "bash": # FIXME: @Cory is this necessary? Doesn't it go against design principles?
             return general_helpers.list_helper(gast, out_lang, " ")
         return general_helpers.list_helper(gast, out_lang)
 

--- a/test/test_bash_primitives.py
+++ b/test/test_bash_primitives.py
@@ -8,18 +8,18 @@ class TestBashPrimitives(unittest2.TestCase):
         js_code = '"hello"'
         bash_code = '"hello"'
         py_code = '"hello"'
-        self.assertEqual(bash_code, main.main(py_code, 'py', 'bash'))
-        self.assertEqual(bash_code, main.main(js_code, 'js', 'bash'))
+        self.assertEqual(bash_code, main.main(py_code, 'py', 'bash')['translation']['output_code'])
+        self.assertEqual(bash_code, main.main(js_code, 'js', 'bash')['translation']['output_code'])
 
     def test_number(self):
         js_code = '46'
         bash_code = '46'
         py_code = '46'
-        self.assertEqual(bash_code, main.main(py_code, 'py', 'bash'))
-        self.assertEqual(bash_code, main.main(js_code, 'js', 'bash'))
+        self.assertEqual(bash_code, main.main(py_code, 'py', 'bash')['translation']['output_code'])
+        self.assertEqual(bash_code, main.main(js_code, 'js', 'bash')['translation']['output_code'])
 
     def test_arr(self):
-        self.assertEqual('(1, 2)', main.main('[1, 2]', 'py', 'bash'))
+        self.assertEqual('(1, 2)', main.main('[1, 2]', 'py', 'bash')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_bin_bool_ops.py
+++ b/test/test_bin_bool_ops.py
@@ -7,110 +7,110 @@ class TestBinBoolOps(unittest2.TestCase):
     def test_bin_no_nesting(self):
         js_code = '1 + 2'
         py_code = '1 + 2'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_bin_left_nesting(self):
         js_code = '1 + 2 + 3'
         py_code = '1 + 2 + 3'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_bin_right_nesting(self):
         js_code = '1 + 2 * 3'
         py_code = '1 + 2 * 3'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_bin_both_nesting(self):
         js_code = '1 * 2 + 3 * 4'
         py_code = '1 * 2 + 3 * 4'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_bin_multilevel_nesting(self):
         js_code = '1 * 2 - 4 / 3 * 4 * 5'
         py_code = '1 * 2 - 4 / 3 * 4 * 5'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_bool_no_nesting(self):
         js_code = 'true && true'
         py_code = 'True and True'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_bool_left_nesting(self):
         js_code = 'true && true || false'
         py_code = 'True and True or False'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_bool_no_nesting_py(self):
         js_code = '1 || 2 || 3 || 4 || 5'
         py_code = '1 or 2 or 3 or 4 or 5'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_bool_right_nesting(self):
         js_code = 'true || true && false'
         py_code = 'True or True and False'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_bool_nesting_no_nest_combo(self):
         js_code = '1 || 2 || 3 || 4 && 6'
         py_code = '1 or 2 or 3 or 4 and 6'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_bool_bin_combo(self):
         js_code = '1 || 2 + 3'
         py_code = '1 or 2 + 3'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_combo_nested(self):
         js_code = '1 || 2 && 3 || 4 + 3'
         py_code = '1 or 2 and 3 or 4 + 3'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_compare_greater_than(self):
         js_code = '1 > 2'
         py_code = '1 > 2'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_compare_less_than_or_equal(self):
         js_code = '1 <= 2'
         py_code = '1 <= 2'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_compare_equal(self):
         js_code = '1 == 2'
         py_code = '1 == 2'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_comparemulti_equal(self):
         js_code = '1 == 2 == 3'
         py_code = '1 == 2 == 3'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_comparemulti_all_ops(self):
         js_code = '1 < 2 <= 3 == 4 >= 5 > 6'
         py_code = '1 < 2 <= 3 == 4 >= 5 > 6'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_comparemulti_strs(self):
         js_code = 'a > b >= c == C'
         py_code = 'a > b >= c == C'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_built_in_functions.py
+++ b/test/test_built_in_functions.py
@@ -5,76 +5,76 @@ import main
 class TestBuiltInFunctions(unittest2.TestCase):
 
     def test_append_statement(self):
-        self.assertEqual('arr.push(x)', main.main('arr.append(x)', 'py', 'js'))
-        self.assertEqual('arr.append(x)', main.main('arr.push(x)', 'js', 'py'))
+        self.assertEqual('arr.push(x)', main.main('arr.append(x)', 'py', 'js')['translation']['output_code'])
+        self.assertEqual('arr.append(x)', main.main('arr.push(x)', 'js', 'py')['translation']['output_code'])
 
     def test_pop_statement(self):
-        self.assertEqual('arr.pop(1)', main.main('arr.pop(1)', 'py', 'js'))
+        self.assertEqual('arr.pop(1)', main.main('arr.pop(1)', 'py', 'js')['translation']['output_code'])
         self.assertEqual('mine.pop(True)',
-                         main.main('mine.pop(true)', 'js', 'py'))
+                         main.main('mine.pop(true)', 'js', 'py')['translation']['output_code'])
 
     def test_array_look_up(self):
-        self.assertEqual('arr[x]', main.main('arr[x]', 'js', 'py'))
-        self.assertEqual('array[3]', main.main('array[3]', 'py', 'js'))
+        self.assertEqual('arr[x]', main.main('arr[x]', 'js', 'py')['translation']['output_code'])
+        self.assertEqual('array[3]', main.main('array[3]', 'py', 'js')['translation']['output_code'])
 
     def test_array_assign(self):
-        self.assertEqual('arr[x] = 6', main.main('arr[x] = 6', 'js', 'py'))
+        self.assertEqual('arr[x] = 6', main.main('arr[x] = 6', 'js', 'py')['translation']['output_code'])
         self.assertEqual('array[3] = []', main.main('array[3] = []', 'py',
                                                     'js'))
 
     def test_sort(self):
-        self.assertEqual('myArr.sort()', main.main('myArr.sort()', 'js', 'py'))
-        self.assertEqual('rr.sort()', main.main('rr.sort()', 'py', 'js'))
+        self.assertEqual('myArr.sort()', main.main('myArr.sort()', 'js', 'py')['translation']['output_code'])
+        self.assertEqual('rr.sort()', main.main('rr.sort()', 'py', 'js')['translation']['output_code'])
 
     def test_extend(self):
         self.assertEqual('arr1.extend(arr2)',
-                         main.main('arr1.concat(arr2)', 'js', 'py'))
+                         main.main('arr1.concat(arr2)', 'js', 'py')['translation']['output_code'])
         self.assertEqual('arr1.concat(arr2)',
-                         main.main('arr1.extend(arr2)', 'py', 'js'))
+                         main.main('arr1.extend(arr2)', 'py', 'js')['translation']['output_code'])
 
     def test_reverse(self):
         self.assertEqual('arr1.reverse()',
-                         main.main('arr1.reverse()', 'js', 'py'))
+                         main.main('arr1.reverse()', 'js', 'py')['translation']['output_code'])
         self.assertEqual('arr1.reverse()',
-                         main.main('arr1.reverse()', 'py', 'js'))
+                         main.main('arr1.reverse()', 'py', 'js')['translation']['output_code'])
 
     def test_string_search(self):
-        self.assertEqual('str.find()', main.main('str.search()', 'js', 'py'))
-        self.assertEqual('str.search()', main.main('str.find()', 'py', 'js'))
+        self.assertEqual('str.find()', main.main('str.search()', 'js', 'py')['translation']['output_code'])
+        self.assertEqual('str.search()', main.main('str.find()', 'py', 'js')['translation']['output_code'])
 
     def test_string_split(self):
-        self.assertEqual('str.split()', main.main('str.split()', 'js', 'py'))
-        self.assertEqual('str.split()', main.main('str.split()', 'py', 'js'))
+        self.assertEqual('str.split()', main.main('str.split()', 'js', 'py')['translation']['output_code'])
+        self.assertEqual('str.split()', main.main('str.split()', 'py', 'js')['translation']['output_code'])
 
     def test_string_lower(self):
         self.assertEqual('str.lower()',
-                         main.main('str.toLowerCase()', 'js', 'py'))
+                         main.main('str.toLowerCase()', 'js', 'py')['translation']['output_code'])
         self.assertEqual('str.toLowerCase()',
-                         main.main('str.lower()', 'py', 'js'))
+                         main.main('str.lower()', 'py', 'js')['translation']['output_code'])
 
     def test_string_upper(self):
         self.assertEqual('str.upper()',
-                         main.main('str.toUpperCase()', 'js', 'py'))
+                         main.main('str.toUpperCase()', 'js', 'py')['translation']['output_code'])
         self.assertEqual('str.toUpperCase()',
-                         main.main('str.upper()', 'py', 'js'))
+                         main.main('str.upper()', 'py', 'js')['translation']['output_code'])
 
     def test_string_index(self):
-        self.assertEqual('str.index()', main.main('str.indexOf()', 'js', 'py'))
-        self.assertEqual('str.indexOf()', main.main('str.index()', 'py', 'js'))
+        self.assertEqual('str.index()', main.main('str.indexOf()', 'js', 'py')['translation']['output_code'])
+        self.assertEqual('str.indexOf()', main.main('str.index()', 'py', 'js')['translation']['output_code'])
 
     def test_string_join(self):
-        self.assertEqual('str.join()', main.main('str.join()', 'js', 'py'))
-        self.assertEqual('str.join()', main.main('str.join()', 'py', 'js'))
+        self.assertEqual('str.join()', main.main('str.join()', 'js', 'py')['translation']['output_code'])
+        self.assertEqual('str.join()', main.main('str.join()', 'py', 'js')['translation']['output_code'])
 
     def test_dictionary_set(self):
         self.assertEqual('dict.update(key, value)',
-                         main.main('dict.set(key,value)', 'js', 'py'))
+                         main.main('dict.set(key,value)', 'js', 'py')['translation']['output_code'])
         self.assertEqual('dict.set(key, value)',
-                         main.main('dict.update(key, value)', 'py', 'js'))
+                         main.main('dict.update(key, value)', 'py', 'js')['translation']['output_code'])
 
     def test_dictionary_keys(self):
-        self.assertEqual('dict.keys()', main.main('dict.keys()', 'js', 'py'))
-        self.assertEqual('dict.keys()', main.main('dict.keys()', 'py', 'js'))
+        self.assertEqual('dict.keys()', main.main('dict.keys()', 'js', 'py')['translation']['output_code'])
+        self.assertEqual('dict.keys()', main.main('dict.keys()', 'py', 'js')['translation']['output_code'])
 
     def test_dictionary_keys(self):
         self.assertEqual('dict.values()', main.main('dict.values()', 'js',
@@ -83,8 +83,8 @@ class TestBuiltInFunctions(unittest2.TestCase):
                                                     'js'))
 
     def test_clear(self):
-        self.assertEqual('clear()', main.main('clear()', 'js', 'py'))
-        self.assertEqual('clear()', main.main('clear()', 'py', 'js'))
+        self.assertEqual('clear()', main.main('clear()', 'js', 'py')['translation']['output_code'])
+        self.assertEqual('clear()', main.main('clear()', 'py', 'js')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_conditionals.py
+++ b/test/test_conditionals.py
@@ -9,45 +9,45 @@ class TestConditionals(unittest2.TestCase):
         py_code = 'if (1):\n\tprint("This is true")'
         bash_code = 'if [[ 1 ]]; then\n\techo "This is true"\nfi'
         java_code = 'if (1) {\n\tSystem.out.println("This is true");\n}'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
-        self.assertEqual(bash_code, main.main(py_code, 'py', 'bash'))
-        self.assertEqual(bash_code, main.main(js_code, 'js', 'bash'))
-        self.assertEqual(java_code, main.main(js_code, 'js', 'java'))
-        self.assertEqual(py_code, main.main(java_code, 'java', 'py'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
+        self.assertEqual(bash_code, main.main(py_code, 'py', 'bash')['translation']['output_code'])
+        self.assertEqual(bash_code, main.main(js_code, 'js', 'bash')['translation']['output_code'])
+        self.assertEqual(java_code, main.main(js_code, 'js', 'java')['translation']['output_code'])
+        self.assertEqual(py_code, main.main(java_code, 'java', 'py')['translation']['output_code'])
 
     def test_else(self):
         js_code = 'if (1) {\n\tconsole.log("1 is true")\n} else {\n\tconsole.log("1 is NOT true")\n}'  # TODO: consider adding ; after console.log()
         py_code = 'if (1):\n\tprint("1 is true")\nelse:\n\tprint("1 is NOT true")'
         bash_code = 'if [[ 1 ]]; then\n\techo "1 is true"\nelse\n\techo "1 is NOT true"\nfi'
         java_code = 'if (1) {\n\tSystem.out.println("1 is true");\n} else {\n\tSystem.out.println("1 is NOT true");\n}'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
-        self.assertEqual(bash_code, main.main(py_code, 'py', 'bash'))
-        self.assertEqual(bash_code, main.main(js_code, 'js', 'bash'))
-        self.assertEqual(java_code, main.main(js_code, 'js', 'java'))
-        self.assertEqual(py_code, main.main(java_code, 'java', 'py'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
+        self.assertEqual(bash_code, main.main(py_code, 'py', 'bash')['translation']['output_code'])
+        self.assertEqual(bash_code, main.main(js_code, 'js', 'bash')['translation']['output_code'])
+        self.assertEqual(java_code, main.main(js_code, 'js', 'java')['translation']['output_code'])
+        self.assertEqual(py_code, main.main(java_code, 'java', 'py')['translation']['output_code'])
 
     def test_elif(self):
         js_code = 'if (1) {\n\tconsole.log("1 is true")\n} else if (2) {\n\tconsole.log("2 is true")\n\tconsole.log("second line")\n}'
         py_code = 'if (1):\n\tprint("1 is true")\nelif (2):\n\tprint("2 is true")\n\tprint("second line")'
         java_code = 'if (1) {\n\tSystem.out.println("1 is true");\n} else if (2) {\n\tSystem.out.println("2 is true");\n\tSystem.out.println("second line");\n}'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
-        self.assertEqual(java_code, main.main(js_code, 'js', 'java'))
-        self.assertEqual(py_code, main.main(java_code, 'java', 'py'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
+        self.assertEqual(java_code, main.main(js_code, 'js', 'java')['translation']['output_code'])
+        self.assertEqual(py_code, main.main(java_code, 'java', 'py')['translation']['output_code'])
 
     def test_elif_else(self):
         js_code = 'if (1) {\n\tconsole.log("1 is true")\n} else if (2) {\n\tconsole.log("2 is true")\n} else {\n\tconsole.log("nothing is true")\n}'
         py_code = 'if (1):\n\tprint("1 is true")\nelif (2):\n\tprint("2 is true")\nelse:\n\tprint("nothing is true")'
         bash_code = 'if [[ 1 ]]; then\n\techo "1 is true"\nelif [[ 2 ]]; then\n\techo "2 is true"\nelse\n\techo "nothing is true"\nfi'
         java_code = 'if (1) {\n\tSystem.out.println("1 is true");\n} else if (2) {\n\tSystem.out.println("2 is true");\n} else {\n\tSystem.out.println("nothing is true");\n}'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
-        self.assertEqual(bash_code, main.main(py_code, 'py', 'bash'))
-        self.assertEqual(bash_code, main.main(js_code, 'js', 'bash'))
-        self.assertEqual(java_code, main.main(js_code, 'js', 'java'))
-        self.assertEqual(py_code, main.main(java_code, 'java', 'py'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
+        self.assertEqual(bash_code, main.main(py_code, 'py', 'bash')['translation']['output_code'])
+        self.assertEqual(bash_code, main.main(js_code, 'js', 'bash')['translation']['output_code'])
+        self.assertEqual(java_code, main.main(js_code, 'js', 'java')['translation']['output_code'])
+        self.assertEqual(py_code, main.main(java_code, 'java', 'py')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_custom_functions.py
+++ b/test/test_custom_functions.py
@@ -5,16 +5,16 @@ import main
 class TestCustomFunctions(unittest2.TestCase):
 
     def test_no_args_no_object(self):
-        self.assertEqual('myFunction()', main.main('myFunction()', 'py', 'js'))
-        self.assertEqual('drive()', main.main('drive()', 'js', 'py'))
-        self.assertEqual('test ', main.main('test()', 'js', 'bash'))
+        self.assertEqual('myFunction()', main.main('myFunction()', 'py', 'js')['translation']['output_code'])
+        self.assertEqual('drive()', main.main('drive()', 'js', 'py')['translation']['output_code'])
+        self.assertEqual('test ', main.main('test()', 'js', 'bash')['translation']['output_code'])
 
     def test_one_arg_no_object(self):
-        self.assertEqual('run("fast")', main.main('run("fast")', 'py', 'js'))
+        self.assertEqual('run("fast")', main.main('run("fast")', 'py', 'js')['translation']['output_code'])
         self.assertEqual('sprint("slow")',
-                         main.main('sprint("slow")', 'js', 'py'))
+                         main.main('sprint("slow")', 'js', 'py')['translation']['output_code'])
         self.assertEqual('hello "joe" 1',
-                         main.main('hello("joe", 1)', 'js', 'bash'))
+                         main.main('hello("joe", 1)', 'js', 'bash')['translation']['output_code'])
 
     def test_object(self):
         self.assertEqual('my.function()', main.main('my.function()', 'js',
@@ -24,14 +24,14 @@ class TestCustomFunctions(unittest2.TestCase):
 
     def test_object_attribute(self):
         self.assertEqual('car.honda.drive(1, 3)',
-                         main.main('car.honda.drive(1,3)', 'js', 'py'))
+                         main.main('car.honda.drive(1,3)', 'js', 'py')['translation']['output_code'])
         self.assertEqual('car.ford.park(null)',
-                         main.main('car.ford.park(None)', 'py', 'js'))
+                         main.main('car.ford.park(None)', 'py', 'js')['translation']['output_code'])
 
     def test_arg_varaible(self):
-        self.assertEqual('test "$file"', main.main('test(file)', 'js', 'bash'))
+        self.assertEqual('test "$file"', main.main('test(file)', 'js', 'bash')['translation']['output_code'])
         self.assertEqual('test "$one" "$two"',
-                         main.main('test(one, two)', 'py', 'bash'))
+                         main.main('test(one, two)', 'py', 'bash')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_dictionaries.py
+++ b/test/test_dictionaries.py
@@ -7,20 +7,20 @@ class TestDictionaries(unittest2.TestCase):
     def test_assignment_with_dict(self):
         js_code = 'let d = {1: 2}'
         py_code = 'd = {1: 2}'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_print_dictionary(self):
         js_code = 'console.log({"first": true})'
         py_code = 'print({"first": True})'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_function_dictionary_argument(self):
         js_code = 'my.function({"4": 1 + 1})'
         py_code = 'my.function({"4": 1 + 1})'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_function_declarations.py
+++ b/test/test_function_declarations.py
@@ -7,89 +7,89 @@ class TestFunctionDeclarations(unittest2.TestCase):
     def test_function_no_args(self):
         js_code = 'function test() {\n\t2\n}'
         py_code = 'def test():\n\t2'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_function_one_arg(self):
         js_code = 'function test(x) {\n\tconsole.log(x)\n}'
         py_code = 'def test(x):\n\tprint(x)'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_function_multiple_args(self):
         js_code = 'function test(x, y, z) {\n\tconsole.log(x + y + z)\n}'
         py_code = 'def test(x, y, z):\n\tprint(x + y + z)'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_function_multi_line_body(self):
         js_code = 'function test(x, y, z) {\n\tconsole.log(x)\n\tconsole.log(y)'
         js_code += '\n\tconsole.log(z)\n}'
         py_code = 'def test(x, y, z):\n\tprint(x)\n\tprint(y)\n\tprint(z)'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_simple_return(self):
         js_code = 'function test() {\n\treturn 1\n}'
         py_code = 'def test():\n\treturn 1'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_complicated_function(self):
         js_code = 'function test(x, y, z) {\n\tconsole.log(x)\n\tconsole.log(y)'
         js_code += '\n\tconsole.log(z)\n\treturn x + y + z\n}'
         py_code = 'def test(x, y, z):\n\tprint(x)\n\tprint(y)\n\tprint(z)'
         py_code += '\n\treturn x + y + z'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_default_vals(self):
         js_code = 'function test(x = 1) {\n\tconsole.log(x)\n}'
         py_code = 'def test(x = 1):\n\tprint(x)'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_multiple_default_vals(self):
         js_code = 'function test(x, y = 2, z = 4, a = 1) {\n\treturn y\n}'
         py_code = 'def test(x, y = 2, z = 4, a = 1):\n\treturn y'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_blank_arrow_functions(self):
         #note python won't compile in this case
         js_arrow = '() => {\n\t\n}'
         py_code = 'lambda:'
-        self.assertEqual(py_code, main.main(js_arrow, 'js', 'py'))
+        self.assertEqual(py_code, main.main(js_arrow, 'js', 'py')['translation']['output_code'])
 
     def test_basic_arrow_functions(self):
         js_arrow = '() => {\n\t1\n}'
         py_code = 'lambda: 1'
-        self.assertEqual(py_code, main.main(js_arrow, 'js', 'py'))
-        self.assertEqual(js_arrow, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_arrow, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_arrow, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_basic_arrow_anon_functions(self):
         js_arrow = 'let a = () => {\n\t1\n}'
         js_anon = 'let a = function() {\n\t1\n}'
         py_code = 'a = lambda: 1'
-        self.assertEqual(py_code, main.main(js_arrow, 'js', 'py'))
-        self.assertEqual(py_code, main.main(js_anon, 'js', 'py'))
-        self.assertEqual(js_arrow, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_arrow, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(py_code, main.main(js_anon, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_arrow, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_arrow_anon_functions_args(self):
         js_arrow = 'let a = (x) => {\n\t1\n}'
         js_anon = 'let a = function(x) {\n\t1\n}'
         py_code = 'a = lambda x: 1'
-        self.assertEqual(py_code, main.main(js_arrow, 'js', 'py'))
-        self.assertEqual(py_code, main.main(js_anon, 'js', 'py'))
-        self.assertEqual(js_arrow, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_arrow, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(py_code, main.main(js_anon, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_arrow, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_arrow_anon_functions_complex(self):
         js_arrow = 'let a = (x, y, z) => {\n\t1\n}'
         js_anon = 'let a = function(x, y, z) {\n\t1\n}'
         py_code = 'a = lambda x, y, z: 1'
-        self.assertEqual(py_code, main.main(js_arrow, 'js', 'py'))
-        self.assertEqual(py_code, main.main(js_anon, 'js', 'py'))
-        self.assertEqual(js_arrow, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_arrow, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(py_code, main.main(js_anon, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_arrow, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_gast_to_code.py
+++ b/test/test_gast_to_code.py
@@ -7,26 +7,26 @@ class TestGastToCode(unittest2.TestCase):
     def test_primitive_str(self):
         gast_str = {"type": "str", "value": "hello world"}
 
-        self.assertEqual('"hello world"', gtc.gast_to_code(gast_str, "py"))
-        self.assertEqual('"hello world"', gtc.gast_to_code(gast_str, "js"))
+        self.assertEqual('"hello world"', gtc.gast_to_code(gast_str, "py")['translation']['output_code'])
+        self.assertEqual('"hello world"', gtc.gast_to_code(gast_str, "js")['translation']['output_code'])
 
     def test_primitive_num(self):
         gast_num = {"type": "num", "value": 47.47}
 
-        self.assertEqual('47.47', gtc.gast_to_code(gast_num, "py"))
-        self.assertEqual('47.47', gtc.gast_to_code(gast_num, "js"))
+        self.assertEqual('47.47', gtc.gast_to_code(gast_num, "py")['translation']['output_code'])
+        self.assertEqual('47.47', gtc.gast_to_code(gast_num, "js")['translation']['output_code'])
 
     def test_primitive_true(self):
         gast_true = {"type": "bool", "value": 1}
 
-        self.assertEqual('True', gtc.gast_to_code(gast_true, "py"))
-        self.assertEqual('true', gtc.gast_to_code(gast_true, "js"))
+        self.assertEqual('True', gtc.gast_to_code(gast_true, "py")['translation']['output_code'])
+        self.assertEqual('true', gtc.gast_to_code(gast_true, "js")['translation']['output_code'])
 
     def test_primitive_false(self):
         gast_false = {"type": "bool", "value": 0}
 
-        self.assertEqual('false', gtc.gast_to_code(gast_false, "js"))
-        self.assertEqual('False', gtc.gast_to_code(gast_false, "py"))
+        self.assertEqual('false', gtc.gast_to_code(gast_false, "js")['translation']['output_code'])
+        self.assertEqual('False', gtc.gast_to_code(gast_false, "py")['translation']['output_code'])
 
     # test other types
     def test_nested_arr(self):
@@ -49,8 +49,8 @@ class TestGastToCode(unittest2.TestCase):
             }]
         }
 
-        self.assertEqual('["hello", [1, 2]]', gtc.gast_to_code(gast_arr, "py"))
-        self.assertEqual('["hello", [1, 2]]', gtc.gast_to_code(gast_arr, "js"))
+        self.assertEqual('["hello", [1, 2]]', gtc.gast_to_code(gast_arr, "py")['translation']['output_code'])
+        self.assertEqual('["hello", [1, 2]]', gtc.gast_to_code(gast_arr, "js")['translation']['output_code'])
 
     def test_binOp_add(self):
         gast_binOp_add = {
@@ -66,8 +66,8 @@ class TestGastToCode(unittest2.TestCase):
             }
         }
 
-        self.assertEqual('3 + 4', gtc.gast_to_code(gast_binOp_add, "py"))
-        self.assertEqual('3 + 4', gtc.gast_to_code(gast_binOp_add, "js"))
+        self.assertEqual('3 + 4', gtc.gast_to_code(gast_binOp_add, "py")['translation']['output_code'])
+        self.assertEqual('3 + 4', gtc.gast_to_code(gast_binOp_add, "js")['translation']['output_code'])
 
     def test_binOp_bitwise(self):
         gast_binOp_bitwise = {
@@ -83,8 +83,8 @@ class TestGastToCode(unittest2.TestCase):
             }
         }
 
-        self.assertEqual('1 & 3', gtc.gast_to_code(gast_binOp_bitwise, "py"))
-        self.assertEqual('1 & 3', gtc.gast_to_code(gast_binOp_bitwise, "js"))
+        self.assertEqual('1 & 3', gtc.gast_to_code(gast_binOp_bitwise, "py")['translation']['output_code'])
+        self.assertEqual('1 & 3', gtc.gast_to_code(gast_binOp_bitwise, "js")['translation']['output_code'])
 
     def test_binOp_add_sub_mult_div(self):
         gast_binOp_add_sub_mult_div = {
@@ -125,9 +125,9 @@ class TestGastToCode(unittest2.TestCase):
         }
 
         self.assertEqual('1 + 2 - 3 * 4 / 5',
-                         gtc.gast_to_code(gast_binOp_add_sub_mult_div, "py"))
+                         gtc.gast_to_code(gast_binOp_add_sub_mult_div, "py")['translation']['output_code'])
         self.assertEqual('1 + 2 - 3 * 4 / 5',
-                         gtc.gast_to_code(gast_binOp_add_sub_mult_div, "js"))
+                         gtc.gast_to_code(gast_binOp_add_sub_mult_div, "js")['translation']['output_code'])
 
     def test_boolOp_and(self):
         gast_boolOp_and = {
@@ -144,9 +144,9 @@ class TestGastToCode(unittest2.TestCase):
         }
 
         self.assertEqual('True and False',
-                         gtc.gast_to_code(gast_boolOp_and, "py"))
+                         gtc.gast_to_code(gast_boolOp_and, "py")['translation']['output_code'])
         self.assertEqual('true && false',
-                         gtc.gast_to_code(gast_boolOp_and, "js"))
+                         gtc.gast_to_code(gast_boolOp_and, "js")['translation']['output_code'])
 
     def test_boolOp_or_and(self):
         gast_boolOp_or_and = {
@@ -171,9 +171,9 @@ class TestGastToCode(unittest2.TestCase):
         }
 
         self.assertEqual('True or False and 4',
-                         gtc.gast_to_code(gast_boolOp_or_and, "py"))
+                         gtc.gast_to_code(gast_boolOp_or_and, "py")['translation']['output_code'])
         self.assertEqual('true || false && 4',
-                         gtc.gast_to_code(gast_boolOp_or_and, "js"))
+                         gtc.gast_to_code(gast_boolOp_or_and, "js")['translation']['output_code'])
 
     # test logStatement
     def test_logStatement_bool(self):
@@ -193,9 +193,9 @@ class TestGastToCode(unittest2.TestCase):
         }
 
         self.assertEqual('print(False)',
-                         gtc.gast_to_code(gast_logStatement_bool, "py"))
+                         gtc.gast_to_code(gast_logStatement_bool, "py")['translation']['output_code'])
         self.assertEqual('console.log(false)',
-                         gtc.gast_to_code(gast_logStatement_bool, "js"))
+                         gtc.gast_to_code(gast_logStatement_bool, "js")['translation']['output_code'])
 
     def test_js_logStatement_two_arguments(self):
         gast_logStatement = {
@@ -216,9 +216,9 @@ class TestGastToCode(unittest2.TestCase):
             }]
         }
         self.assertEqual('print("hello world", 5)',
-                         gtc.gast_to_code(gast_logStatement, "py"))
+                         gtc.gast_to_code(gast_logStatement, "py")['translation']['output_code'])
         self.assertEqual('console.log("hello world", 5)',
-                         gtc.gast_to_code(gast_logStatement, "js"))
+                         gtc.gast_to_code(gast_logStatement, "js")['translation']['output_code'])
 
     # test varAssign
     def test_js_varAssign_let(self):
@@ -239,7 +239,7 @@ class TestGastToCode(unittest2.TestCase):
             },]
         }
 
-        self.assertEqual('x = 5', gtc.gast_to_code(gast_varAssign_let, "py"))
+        self.assertEqual('x = 5', gtc.gast_to_code(gast_varAssign_let, "py")['translation']['output_code'])
         self.assertEqual('let x = 5', gtc.gast_to_code(gast_varAssign_let,
                                                        "js"))
 
@@ -261,9 +261,9 @@ class TestGastToCode(unittest2.TestCase):
             },]
         }
 
-        self.assertEqual('x = 5', gtc.gast_to_code(gast_varAssign_const, "py"))
+        self.assertEqual('x = 5', gtc.gast_to_code(gast_varAssign_const, "py")['translation']['output_code'])
         self.assertEqual('const x = 5',
-                         gtc.gast_to_code(gast_varAssign_const, "js"))
+                         gtc.gast_to_code(gast_varAssign_const, "js")['translation']['output_code'])
 
     # test multiple items in body
     def test_multi_body(self):
@@ -298,7 +298,7 @@ class TestGastToCode(unittest2.TestCase):
             ]
         }
         self.assertEqual('x = 5\nx = 5',
-                         gtc.gast_to_code(gast_multi_body, "py"))
+                         gtc.gast_to_code(gast_multi_body, "py")['translation']['output_code'])
 
     def test_if(self):
         input_gast = {
@@ -324,10 +324,10 @@ class TestGastToCode(unittest2.TestCase):
             }]
         }
         expected_js = 'if (true) {\n\tconsole.log("This is true")\n}'
-        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js"))
+        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js")['translation']['output_code'])
 
         expected_py = 'if (True):\n\tprint("This is true")'
-        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py"))
+        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py")['translation']['output_code'])
 
     def test_else(self):
         input_gast = {
@@ -363,10 +363,10 @@ class TestGastToCode(unittest2.TestCase):
         }
 
         expected_js = 'if (1) {\n\tconsole.log("1 is true")\n} else {\n\tconsole.log("1 is NOT true")\n}'  # TODO: consider adding ; after console.log()
-        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js"))
+        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js")['translation']['output_code'])
 
         expected_py = 'if (1):\n\tprint("1 is true")\nelse:\n\tprint("1 is NOT true")'
-        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py"))
+        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py")['translation']['output_code'])
 
     def test_elif(self):
         input_gast = {
@@ -421,8 +421,8 @@ class TestGastToCode(unittest2.TestCase):
         expected_py = 'if (1):\n\tprint("1 is true")\nelif (2):\n\tprint("2 is true")\n\tprint("second line")'
         expected_js = 'if (1) {\n\tconsole.log("1 is true")\n} else if (2) {\n\tconsole.log("2 is true")\n\tconsole.log("second line")\n}'
 
-        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py"))
-        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js"))
+        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py")['translation']['output_code'])
+        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js")['translation']['output_code'])
 
     def test_forRange(self):
         input_gast = {
@@ -472,8 +472,8 @@ class TestGastToCode(unittest2.TestCase):
         expected_js = 'for (let i = 0; i < 10; i += 2) {\n\t5\n}'
         expected_py = 'for i in range (0, 10, 2):\n\t5'
 
-        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py"))
-        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js"))
+        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py")['translation']['output_code'])
+        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js")['translation']['output_code'])
 
     def test_forOf(self):
         input_gast = {
@@ -502,8 +502,8 @@ class TestGastToCode(unittest2.TestCase):
         expected_js = 'for (elem of [1, 2]) {\n\t5\n}'
         expected_py = 'for elem in [1, 2]:\n\t5'
 
-        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py"))
-        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js"))
+        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py")['translation']['output_code'])
+        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js")['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_gast_to_code_indentation.py
+++ b/test/test_gast_to_code_indentation.py
@@ -53,10 +53,10 @@ class TestGastToCodeIndentation(unittest2.TestCase):
         }
 
         expected_js = 'if (x == true) {\n\tif (y == true) {\n\t\tconsole.log("y and x are true")\n\t}\n}'
-        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js"))
+        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js")['translation']['output_code'])
 
         expected_py = 'if (x == True):\n\tif (y == True):\n\t\tprint("y and x are true")'
-        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py"))
+        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py")['translation']['output_code'])
 
     def test_indent_for_of(self):
         input_gast = {
@@ -110,10 +110,10 @@ class TestGastToCodeIndentation(unittest2.TestCase):
         }
 
         expected_js = 'for (j of [1, 2]) {\n\tfor (k of [3, 4]) {\n\t\tj\n\t\tk\n\t}\n}'
-        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js"))
+        self.assertEqual(expected_js, gtc.gast_to_code(input_gast, "js")['translation']['output_code'])
 
         expected_py = 'for j in [1, 2]:\n\tfor k in [3, 4]:\n\t\tj\n\t\tk'
-        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py"))
+        self.assertEqual(expected_py, gtc.gast_to_code(input_gast, "py")['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_indentation.py
+++ b/test/test_indentation.py
@@ -8,43 +8,43 @@ class TestIndentation(unittest2.TestCase):
         js_code = 'if (x == true) {\n\tif (y == true) {\n\t\tconsole.log("y and x are true")\n\t}\n}'
         py_code = 'if (x == True):\n\tif (y == True):\n\t\tprint("y and x are true")'
 
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_indent_for_of(self):
         js_code = 'for (j of [1, 2]) {\n\tfor (k of [3, 4]) {\n\t\tj\n\t\tk\n\t}\n}'
         py_code = 'for j in [1, 2]:\n\tfor k in [3, 4]:\n\t\tj\n\t\tk'
 
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_indent_for_range(self):
         js_code = 'for (let j = 0; j < 10; j += 1) {\n\tfor (let k = 20; k < 30; k += 1) {\n\t\tj\n\t\tk\n\t}\n}'
         py_code = 'for j in range (0, 10, 1):\n\tfor k in range (20, 30, 1):\n\t\tj\n\t\tk'
 
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_indent_while(self):
         js_code = 'while (1) {\n\twhile (2) {\n\t\t3\n\t}\n}'
         py_code = 'while (1):\n\twhile (2):\n\t\t3'
 
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_indent_func_and_if(self):
         js_code = 'function test() {\n\tif (1) {\n\t\t2\n\t}\n}'
         py_code = 'def test():\n\tif (1):\n\t\t2'
 
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_indent_func_if_while_for(self):
         js_code = 'function test() {\n\tif (1) {\n\t\twhile (2) {\n\t\t\tfor (j of [3, 4]) {\n\t\t\t\t5\n\t\t\t}\n\t\t}\n\t}\n}'
         py_code = 'def test():\n\tif (1):\n\t\twhile (2):\n\t\t\tfor j in [3, 4]:\n\t\t\t\t5'
 
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_java_arr.py
+++ b/test/test_java_arr.py
@@ -5,12 +5,12 @@ import main
 class TestJavaArr(unittest2.TestCase):
 
     def test_arr_to_code(self):
-        self.assertEqual('{1, 2};', main.main('[1, 2]', 'py', 'java'))
+        self.assertEqual('{1, 2};', main.main('[1, 2]', 'py', 'java')['translation']['output_code'])
 
     def test_log_arr_to_code(self):
         py_input = 'print([1, 2, 3])'
         expected = 'System.out.println(Arrays.toString(new int[] {1, 2, 3}));'
-        self.assertEqual(expected, main.main(py_input, 'py', 'java'))
+        self.assertEqual(expected, main.main(py_input, 'py', 'java')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_java_assignment.py
+++ b/test/test_java_assignment.py
@@ -7,11 +7,11 @@ class TestJavaAssignment(unittest2.TestCase):
     def test_basic(self):
         code = 'int x = 1;\n String s = "s";\nboolean b = false;'
         self.assertEqual('int x = 1;\nString s = "s";\nboolean b = false;',
-                         main.main(code, 'java', 'java'))
+                         main.main(code, 'java', 'java')['translation']['output_code'])
 
     def test_arr(self):
         self.assertEqual('int[] x = {1, 2};',
-                         main.main('int[] x = {1, 2};', 'java', 'java'))
+                         main.main('int[] x = {1, 2};', 'java', 'java')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_java_function.py
+++ b/test/test_java_function.py
@@ -6,25 +6,25 @@ class TestJavaFunctionCalls(unittest2.TestCase):
 
     def test_basic(self):
         code = 'myFunction();'
-        self.assertEqual('myFunction();', main.main(code, 'java', 'java'))
+        self.assertEqual('myFunction();', main.main(code, 'java', 'java')['translation']['output_code'])
 
     def test_basic_args(self):
         code = 'myFunction(1, "str", true);'
         self.assertEqual('myFunction(1, "str", true);',
-                         main.main(code, 'java', 'java'))
+                         main.main(code, 'java', 'java')['translation']['output_code'])
 
     def test_function_on_object(self):
         code = 'car.drive("hi");'
-        self.assertEqual('car.drive("hi");', main.main(code, 'java', 'java'))
+        self.assertEqual('car.drive("hi");', main.main(code, 'java', 'java')['translation']['output_code'])
 
     def test_function_multiple_objects(self):
         code = 'nice.car.drive();'
-        self.assertEqual('nice.car.drive();', main.main(code, 'java', 'java'))
+        self.assertEqual('nice.car.drive();', main.main(code, 'java', 'java')['translation']['output_code'])
 
     def test_complex_function(self):
         code = 'really.fancy.and.nice.car.drive();'
         self.assertEqual('really.fancy.and.nice.car.drive();',
-                         main.main(code, 'java', 'java'))
+                         main.main(code, 'java', 'java')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_java_primitives.py
+++ b/test/test_java_primitives.py
@@ -8,12 +8,12 @@ class TestJavaPrim(unittest2.TestCase):
     def test_basic(self):
         code = "System.out.println();"
         self.assertEqual("System.out.println();",
-                         main.main(code, 'java', 'java'))
+                         main.main(code, 'java', 'java')['translation']['output_code'])
 
     def test_basic_args(self):
         code = 'System.out.println("s");'
         self.assertEqual('System.out.println("s");',
-                         main.main(code, 'java', 'java'))
+                         main.main(code, 'java', 'java')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_log_statement.py
+++ b/test/test_log_statement.py
@@ -5,36 +5,36 @@ import main
 class TestLogStatement(unittest2.TestCase):
 
     def test_no_args(self):
-        self.assertEqual('console.log()', main.main('print()', 'py', 'js'))
-        self.assertEqual('print()', main.main('console.log()', 'js', 'py'))
+        self.assertEqual('console.log()', main.main('print()', 'py', 'js')['translation']['output_code'])
+        self.assertEqual('print()', main.main('console.log()', 'js', 'py')['translation']['output_code'])
 
     def test_one_arg(self):
         self.assertEqual('console.log("hello")',
-                         main.main('print("hello")', 'py', 'js'))
-        self.assertEqual('print(5)', main.main('console.log(5)', 'js', 'py'))
-        self.assertEqual('echo 8', main.main('console.log(8)', 'js', 'bash'))
+                         main.main('print("hello")', 'py', 'js')['translation']['output_code'])
+        self.assertEqual('print(5)', main.main('console.log(5)', 'js', 'py')['translation']['output_code'])
+        self.assertEqual('echo 8', main.main('console.log(8)', 'js', 'bash')['translation']['output_code'])
 
     def test_quotes_string(self):
         self.assertEqual('print("working")',
-                         main.main('console.log("working")', 'js', 'py'))
+                         main.main('console.log("working")', 'js', 'py')['translation']['output_code'])
 
     def test_arrays(self):
         self.assertEqual('print([[1, 3], [3, 4]])',
-                         main.main('console.log([[1, 3], [3,4]])', 'js', 'py'))
+                         main.main('console.log([[1, 3], [3,4]])', 'js', 'py')['translation']['output_code'])
         self.assertEqual('console.log(["hi", "bye"])',
-                         main.main('print(["hi", "bye"])', 'py', 'js'))
+                         main.main('print(["hi", "bye"])', 'py', 'js')['translation']['output_code'])
 
     def test_boolean(self):
         self.assertEqual('print(True)',
-                         main.main('console.log(true)', 'js', 'py'))
+                         main.main('console.log(true)', 'js', 'py')['translation']['output_code'])
         self.assertEqual('console.log(!false)',
-                         main.main('print(not False)', 'py', 'js'))
+                         main.main('print(not False)', 'py', 'js')['translation']['output_code'])
 
     def test_none(self):
         self.assertEqual('console.log(null)',
-                         main.main('print(None)', 'py', 'js'))
+                         main.main('print(None)', 'py', 'js')['translation']['output_code'])
         self.assertEqual('print(None)',
-                         main.main('console.log(null)', 'js', 'py'))
+                         main.main('console.log(null)', 'js', 'py')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -7,20 +7,20 @@ class TestLoops(unittest2.TestCase):
     def test_while_simple(self):
         js_code = 'while (true) {\n\t5\n}'
         py_code = 'while (True):\n\t5'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_while_range(self):
         js_code = 'while (x < 10) {\n\t5\n}'
         py_code = 'while (x < 10):\n\t5'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_for_range_increment_one(self):
         js_code = 'for (let i = 0; i < 10; i += 1) {\n\t5\n}'
         py_code = 'for i in range (0, 10, 1):\n\t5'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     """
     When python's step argument is ommitted, step=1. This test checks
@@ -30,13 +30,13 @@ class TestLoops(unittest2.TestCase):
     def test_for_range_implied_increment_one(self):
         input_py_code = 'for i in range (0, 10):\n\t5'
         expected_js_code = 'for (let i = 0; i < 10; i += 1) {\n\t5\n}'
-        self.assertEqual(expected_js_code, main.main(input_py_code, 'py', 'js'))
+        self.assertEqual(expected_js_code, main.main(input_py_code, 'py', 'js')['translation']['output_code'])
 
     def test_for_range_increment_two(self):
         js_code = 'for (let i = 0; i < 10; i += 2) {\n\t5\n}'
         py_code = 'for i in range (0, 10, 2):\n\t5'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     """
     Since python does not have inclusive range, it needs to adjust the end point
@@ -46,34 +46,34 @@ class TestLoops(unittest2.TestCase):
     def test_for_inclusiverange_increment_two(self):
         input_js_code = 'for (let i = 0; i <= 10; i += 2) {\n\t5\n}'
         expected_py_code = 'for i in range (0, 12, 2):\n\t5'
-        self.assertEqual(expected_py_code, main.main(input_js_code, 'js', 'py'))
+        self.assertEqual(expected_py_code, main.main(input_js_code, 'js', 'py')['translation']['output_code'])
 
     def test_for_with_update_expression_plus(self):
         input_js_code = 'for (let i = 0; i <= 10; i++) {\n\t5\n}'
         expected_py_code = 'for i in range (0, 11, 1):\n\t5'
-        self.assertEqual(expected_py_code, main.main(input_js_code, 'js', 'py'))
+        self.assertEqual(expected_py_code, main.main(input_js_code, 'js', 'py')['translation']['output_code'])
 
     def test_for_with_update_expression_minus(self):
         input_js_code = 'for (let i = 20; i >= -5; i--) {\n\t5\n}'
         expected_py_code = 'for i in range (20, -4, -1):\n\t5'
-        self.assertEqual(expected_py_code, main.main(input_js_code, 'js', 'py'))
+        self.assertEqual(expected_py_code, main.main(input_js_code, 'js', 'py')['translation']['output_code'])
 
     def test_for_loop_python_incrementor(self):
         input_py_code = 'for i in range(0,10,1): \n\t5'
         expected_js_code = 'for (let i = 0; i < 10; i += 1) {\n\t5\n}'
-        self.assertEqual(expected_js_code, main.main(input_py_code, 'py', 'js'))
+        self.assertEqual(expected_js_code, main.main(input_py_code, 'py', 'js')['translation']['output_code'])
 
     def test_for_range_increment_negative(self):
         js_code = 'for (let i = 10; i > 0; i -= 1) {\n\t5\n}'
         py_code = 'for i in range (10, 0, -1):\n\t5'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_for_range_all_args_neg(self):
         js_code = 'for (let i = -25; i > -50; i -= 5) {\n\t5\n}'
         py_code = 'for i in range (-25, -50, -5):\n\t5'
-        self.assertEqual(py_code, main.main(js_code, 'js', 'py'))
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(py_code, main.main(js_code, 'js', 'py')['translation']['output_code'])
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
     def test_for_range_one_arg_loop(self):
         ''' 
@@ -82,7 +82,7 @@ class TestLoops(unittest2.TestCase):
         '''
         js_code = 'for (let i = 0; i < 5; i += 1) {\n\tconsole.log(i)\n}'
         py_code = 'for i in range (5):\n\tprint(i)'
-        self.assertEqual(js_code, main.main(py_code, 'py', 'js'))
+        self.assertEqual(js_code, main.main(py_code, 'py', 'js')['translation']['output_code'])
 
 
 if __name__ == '__main__':

--- a/test/test_var_assign.py
+++ b/test/test_var_assign.py
@@ -5,52 +5,52 @@ import main
 class TestVarAssign(unittest2.TestCase):
 
     def test_string_assign(self):
-        self.assertEqual('x = "hi"', main.main('let x = "hi"', 'js', 'py'))
+        self.assertEqual('x = "hi"', main.main('let x = "hi"', 'js', 'py')['translation']['output_code'])
         self.assertEqual('let test = "working"',
-                         main.main('test = "working"', 'py', 'js'))
+                         main.main('test = "working"', 'py', 'js')['translation']['output_code'])
         self.assertEqual('test="working"',
-                         main.main('test = "working"', 'py', 'bash'))
+                         main.main('test = "working"', 'py', 'bash')['translation']['output_code'])
 
     def test_int_assign(self):
-        self.assertEqual('num = 109', main.main('const num = 109', 'js', 'py'))
-        self.assertEqual('let n = 12', main.main('n = 12', 'py', 'js'))
-        self.assertEqual('n=12', main.main('n = 12', 'py', 'bash'))
+        self.assertEqual('num = 109', main.main('const num = 109', 'js', 'py')['translation']['output_code'])
+        self.assertEqual('let n = 12', main.main('n = 12', 'py', 'js')['translation']['output_code'])
+        self.assertEqual('n=12', main.main('n = 12', 'py', 'bash')['translation']['output_code'])
 
     def test_array_assign(self):
         self.assertEqual('arr = [3, 6]',
-                         main.main('let arr = [3, 6]', 'js', 'py'))
+                         main.main('let arr = [3, 6]', 'js', 'py')['translation']['output_code'])
         self.assertEqual('let nest = [[1, 9], [2, 8]]',
-                         main.main('nest = [[1,9],[2,8]]', 'py', 'js'))
+                         main.main('nest = [[1,9],[2,8]]', 'py', 'js')['translation']['output_code'])
 
     def test_boolean_assign(self):
         self.assertEqual('boo = not True',
-                         main.main('const boo=!true', 'js', 'py'))
+                         main.main('const boo=!true', 'js', 'py')['translation']['output_code'])
         self.assertEqual('let lean = false',
-                         main.main('lean = False', 'py', 'js'))
+                         main.main('lean = False', 'py', 'js')['translation']['output_code'])
 
     def test_none_assign(self):
-        self.assertEqual('no = None', main.main('let no =null', 'js', 'py'))
+        self.assertEqual('no = None', main.main('let no =null', 'js', 'py')['translation']['output_code'])
         self.assertEqual('let help = null', main.main('help = None', 'py',
                                                       'js'))
 
     def test_aug_assign_minus(self):
-        self.assertEqual('x -= 1', main.main('x -= 1', 'js', 'py'))
-        self.assertEqual('y -= 3', main.main('y-=3', 'py', 'js'))
+        self.assertEqual('x -= 1', main.main('x -= 1', 'js', 'py')['translation']['output_code'])
+        self.assertEqual('y -= 3', main.main('y-=3', 'py', 'js')['translation']['output_code'])
 
     def test_aug_assign_mult(self):
-        self.assertEqual('hi *= 5', main.main('hi *= 5', 'js', 'py'))
-        self.assertEqual('y *= 4', main.main('y*=4', 'py', 'js'))
+        self.assertEqual('hi *= 5', main.main('hi *= 5', 'js', 'py')['translation']['output_code'])
+        self.assertEqual('y *= 4', main.main('y*=4', 'py', 'js')['translation']['output_code'])
 
     def test_update_expression(self):
         output_py_code = "x += 1"
         js_code = "x++"
         bash_code = "x++"
         java_code = "x++;"
-        self.assertEqual(output_py_code, main.main(js_code, "js", "py"))
-        self.assertEqual(bash_code, main.main(java_code, "java", "bash"))
-        self.assertEqual(bash_code, main.main(js_code, "js", "bash"))
-        self.assertEqual(java_code, main.main(js_code, "js", "java"))
-        self.assertEqual(bash_code, main.main(java_code, "java", "bash"))
+        self.assertEqual(output_py_code, main.main(js_code, "js", "py")['translation']['output_code'])
+        self.assertEqual(bash_code, main.main(java_code, "java", "bash")['translation']['output_code'])
+        self.assertEqual(bash_code, main.main(js_code, "js", "bash")['translation']['output_code'])
+        self.assertEqual(java_code, main.main(js_code, "js", "java")['translation']['output_code'])
+        self.assertEqual(bash_code, main.main(java_code, "java", "bash")['translation']['output_code'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
First step was to fix all of the tests so that anything that was expecting an output from main or gast to code would test an object rather than a string. Since we have over 130 tests, I decided to use regex rather than manually fixing all of the tests.

### Regex for tests using main.main:
```
main.main\((.*)\)\) # find
main.main($1)['translation']['output_code']) # replace
```

### Regex for tests using gtc.gast_to_code:
```
gtc.gast_to_code\((.*)\)\) # find
gtc.gast_to_code($1)['translation']['output_code']) # replace
```