### PR TITLE
Fix Bug in Unsupported Error

### DIFF
--- a/bash/gast_to_code/bash_gast_to_code_converter.py
+++ b/bash/gast_to_code/bash_gast_to_code_converter.py
@@ -92,7 +92,7 @@ class BashGastToCodeConverter():
 
     def handle_dict(self, gast):
         return self.error_handler.unsupported_feature()
-    
+
     def handle_property(self, gast):
         return self.error_handler.unsupported_feature()
 

--- a/bash/gast_to_code/bash_gast_to_code_converter.py
+++ b/bash/gast_to_code/bash_gast_to_code_converter.py
@@ -16,9 +16,6 @@ class BashGastToCodeConverter():
     def get_error_handler(self):
         return self.error_handler
 
-    def handle_bool(self, gast):
-        return "Bash does not support booleans"
-
     def handle_log_statement(self, gast):
         return "echo"
 
@@ -71,3 +68,51 @@ class BashGastToCodeConverter():
 
     def handle_root(self, gast):
         return general_helpers.list_helper(gast["body"], "bash", "\n")
+
+    def handle_bool(self, gast):
+        return self.error_handler.impossible_translation()
+
+    def handle_none(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_while(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_for_range(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_for_of(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_subscript(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_built_in_attribute(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_dict(self, gast):
+        return self.error_handler.unsupported_feature()
+    
+    def handle_property(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_bool_op(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_unary_op(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_function_declaration(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_return_statement(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_assign_pattern(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_arrow_func(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_attribute(self, gast):
+        return self.error_handler.unsupported_feature()

--- a/java/gast_to_code/gast_to_code_java.py
+++ b/java/gast_to_code/gast_to_code_java.py
@@ -32,7 +32,7 @@ class JavaGastToCodeConverter():
         out = 'if (' + test + ') {' + body_indent + body + closing_brace_indent + "}"
 
         if len(gast["orelse"]) == 0:
-            pass
+            return pass
         elif gast["orelse"][0]["type"] == "if":
             out += " else " + router.gast_to_code(gast["orelse"], "java")
         else:
@@ -116,7 +116,8 @@ class JavaGastToCodeConverter():
                                        gast["args"], "java") + ")"
 
     def handle_subscript(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
+
 
     def handle_name(self, gast):
         ''' 
@@ -132,19 +133,24 @@ class JavaGastToCodeConverter():
         return router.gast_to_code(gast["value"], "java") + "." + gast["id"]
 
     def handle_built_in_attribute(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
+
 
     def handle_dict(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
+
 
     def handle_property(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
+
 
     def handle_bool_op(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
+
 
     def handle_unary_op(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
+
 
     '''
     Translates gAST node to java function. Whether a function is static or
@@ -173,24 +179,23 @@ class JavaGastToCodeConverter():
         return out
 
     def handle_return_statement(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
 
     def handle_assign_pattern(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
 
     def handle_arr(self, gast):
         return "{" + router.gast_to_code(gast["elements"], "java") + "}"
 
-    '''
-    This is called when the root of a java ast is found. The body of the 
-    AST is handled seperately - the functions are handled and then the 
-    statements outside of functions are handled. If there are both functions
-    and body statements a class with the functions and a main function with 
-    body statements is returned. If there is just body statements the translated
-    body statements will be returned. 
-    '''
-
     def handle_root(self, gast):
+        '''
+        This is called when the root of a java ast is found. The body of the 
+        AST is handled seperately - the functions are handled and then the 
+        statements outside of functions are handled. If there are both functions
+        and body statements a class with the functions and a main function with 
+        body statements is returned. If there is just body statements the translated
+        body statements will be returned. 
+        '''
         function_output = java_helpers.java_node_list_helper(
             gast["body"], True, "\n\t", 1)
 
@@ -215,3 +220,6 @@ class JavaGastToCodeConverter():
             out += "\n}"
 
         return out
+
+    def handle_arrow_func(self, gast):
+        return self.error_handler.unsupported_feature()

--- a/java/gast_to_code/gast_to_code_java.py
+++ b/java/gast_to_code/gast_to_code_java.py
@@ -32,7 +32,7 @@ class JavaGastToCodeConverter():
         out = 'if (' + test + ') {' + body_indent + body + closing_brace_indent + "}"
 
         if len(gast["orelse"]) == 0:
-            return pass
+            pass
         elif gast["orelse"][0]["type"] == "if":
             out += " else " + router.gast_to_code(gast["orelse"], "java")
         else:
@@ -118,7 +118,6 @@ class JavaGastToCodeConverter():
     def handle_subscript(self, gast):
         return self.error_handler.unsupported_feature()
 
-
     def handle_name(self, gast):
         ''' 
         NOTE: some places store {"type": "name", "value": "s"} while others have
@@ -135,22 +134,17 @@ class JavaGastToCodeConverter():
     def handle_built_in_attribute(self, gast):
         return self.error_handler.unsupported_feature()
 
-
     def handle_dict(self, gast):
         return self.error_handler.unsupported_feature()
-
 
     def handle_property(self, gast):
         return self.error_handler.unsupported_feature()
 
-
     def handle_bool_op(self, gast):
         return self.error_handler.unsupported_feature()
 
-
     def handle_unary_op(self, gast):
         return self.error_handler.unsupported_feature()
-
 
     '''
     Translates gAST node to java function. Whether a function is static or


### PR DESCRIPTION
gast to code router was calling handlers that did not exist or did not do anything in java and bash. I added in these handlers and made them return unsupported errors using error_handler