### PR TITLE
added handlers for java and bash indicating unsupported features

### DIFF
--- a/bash/gast_to_code/bash_gast_to_code_converter.py
+++ b/bash/gast_to_code/bash_gast_to_code_converter.py
@@ -16,9 +16,6 @@ class BashGastToCodeConverter():
     def get_error_handler(self):
         return self.error_handler
 
-    def handle_bool(self, gast):
-        return "Bash does not support booleans"
-
     def handle_log_statement(self, gast):
         return "echo"
 
@@ -71,3 +68,51 @@ class BashGastToCodeConverter():
 
     def handle_root(self, gast):
         return general_helpers.list_helper(gast["body"], "bash", "\n")
+
+    def handle_bool(self, gast):
+        return self.error_handler.impossible_translation()
+
+    def handle_none(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_while(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_for_range(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_for_of(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_subscript(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_built_in_attribute(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_dict(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_property(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_bool_op(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_unary_op(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_function_declaration(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_return_statement(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_assign_pattern(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_arrow_func(self, gast):
+        return self.error_handler.unsupported_feature()
+
+    def handle_attribute(self, gast):
+        return self.error_handler.unsupported_feature()

--- a/java/gast_to_code/gast_to_code_java.py
+++ b/java/gast_to_code/gast_to_code_java.py
@@ -116,7 +116,7 @@ class JavaGastToCodeConverter():
                                        gast["args"], "java") + ")"
 
     def handle_subscript(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
 
     def handle_name(self, gast):
         ''' 
@@ -132,19 +132,19 @@ class JavaGastToCodeConverter():
         return router.gast_to_code(gast["value"], "java") + "." + gast["id"]
 
     def handle_built_in_attribute(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
 
     def handle_dict(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
 
     def handle_property(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
 
     def handle_bool_op(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
 
     def handle_unary_op(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
 
     '''
     Translates gAST node to java function. Whether a function is static or
@@ -173,10 +173,13 @@ class JavaGastToCodeConverter():
         return out
 
     def handle_return_statement(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
 
     def handle_assign_pattern(self, gast):
-        pass
+        return self.error_handler.unsupported_feature()
+
+    def handle_arrow_func(self, gast):
+        return self.error_handler.unsupported_feature()
 
     def handle_arr(self, gast):
         return "{" + router.gast_to_code(gast["elements"], "java") + "}"


### PR DESCRIPTION
gast to code router was calling handlers that did not exist or did not do anything in java and bash. I added in these handlers and made them return unsupported errors using error_handler

