### PR TITLE
Hot fix: Restructure gast to remove {type: name} having either id or value

### DIFF
--- a/java/code_to_gast/java_expression.py
+++ b/java/code_to_gast/java_expression.py
@@ -29,7 +29,7 @@ def method_invocation_to_gast(node):
 Takes list of callees and members and from function called
 on object and translates into gAST node
 Ex: car.drive() -> {"type": "attribute", "id": "drive", "value": 
-{"type": "name", "id": "car"}}
+{"type": "name", "value": "car"}}
 '''
 
 
@@ -39,7 +39,7 @@ def list_to_attribute_value_node(object_list):
     gast["id"] = object_list.pop()
 
     if len(object_list) == 1:
-        gast["value"] = {"type": "name", "id": object_list.pop()}
+        gast["value"] = {"type": "name", "value": object_list.pop()}
     else:
         gast["value"] = list_to_attribute_value_node(object_list)
 

--- a/java/gast_to_code/gast_to_code_java.py
+++ b/java/gast_to_code/gast_to_code_java.py
@@ -119,14 +119,7 @@ class JavaGastToCodeConverter():
         return self.error_handler.unsupported_feature()
 
     def handle_name(self, gast):
-        ''' 
-        NOTE: some places store {"type": "name", "value": "s"} while others have
-        {"type": "name", "id" : "s"} in gAST but both get routed to this func.
-        We may want to re-evaluate gAST structure regarding funcs and vars
-        '''
-        if "value" in gast:
-            return gast["value"]
-        return gast["id"]
+        return gast["value"]
 
     def handle_attribute(self, gast):
         return router.gast_to_code(gast["value"], "java") + "." + gast["id"]


### PR DESCRIPTION
Our old gast had instances of {"type": "name", "value": "x"} and {"type": "name", "id": "x"}. I removed all instances of {"type": "name", "id": "x"} and changed id to value and updated the GAST contract doc. It turns out a lot of examples in the contract used id but the code_to_gast used value. Note: there are places that use id however they are {"type": "attribute", "id": .... }