### PR TITLE
lingering issue: fixed java to python issue with for loops

### DIFF
--- a/python/gast_to_code/py_gast_to_code_converter.py
+++ b/python/gast_to_code/py_gast_to_code_converter.py
@@ -56,12 +56,13 @@ class PyGastToCodeConverter():
         return out
 
     def handle_for_range(self, gast, lvl=0):
-        # deals with init
-        if (gast["init"]["type"] == "varAssign"):
+        # deals with init TODO: streamline java and javascript to gast to make this easier
+        if (type(gast["init"]) == dict and gast["init"]["type"] == "varAssign"):
             start = str(gast["init"]["varValue"]["value"])
             var_name = gast["init"]["varId"]["value"]
 
-        elif ("right" in gast["init"] and "left" in gast["init"]):
+        elif (type(gast["init"]) == dict and "right" in gast["init"] and
+              "left" in gast["init"]):
             start = str(gast["init"]["right"]["value"])
             var_name = gast["init"]["left"]["value"]
         else:

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -1,5 +1,6 @@
 import unittest2
 import translate
+import main
 
 
 class TestLoops(unittest2.TestCase):
@@ -35,6 +36,12 @@ class TestLoops(unittest2.TestCase):
         js_code = 'for(i=0; i<10; i+=1){\n\t5\n}'
         py_code = 'for i in range (0, 10, 1):\n\t5'
         self.assertEqual(py_code, translate.translate(js_code, 'js', 'py'))
+
+    def test_for_range_without_let_java(self):
+        java_code = 'for(i=0; i<10; i+=1){\n\t5;\n}'
+        py_code = 'for $$E1$$ in range ($$E0$$, 10, 1):\n\t5'
+        self.assertEqual(py_code,
+                         main.main(java_code, 'java', 'py')["translation"])
 
     def test_for_range_without_let_negative(self):
         js_code = 'for(i=-5; i<10; i+=1){\n\t5\n}'


### PR DESCRIPTION
Error was produced for the following java code to python 
```
for(i=0; i<10; i+=1){\n\t5;\n}
```
This is because java to gast was returning a list in the init node rather than a dict as python gast to code was [expecting](https://docs.google.com/document/d/1Ycs8fz0tgYBZrnu2EKR8XvO3nq_6eW5jSDmBKLl37Mo/edit#bookmark=id.43aa9tcspiou).
Made a temporary fix but added a TODO to fix the way java and javascript build gast to conform with contract