### PR TITLE
Hot Fix: Throw error if user types java class

### DIFF
--- a/java/code_to_gast/java_main.py
+++ b/java/code_to_gast/java_main.py
@@ -27,12 +27,17 @@ def java_to_gast(java_input):
 
     # try to compile java with both wrappers - if one compiles start to build ast
     try:
-        input_ast = javalang.parse.parse(class_main_wrapped)
+        # if input compiles without wrapper it includes a class which is unsupported
+        input_ast = javalang.parse.parse(java_input)
+        # throw an error since classes are not supported 
+        return None
     except:
         try:
-            input_ast = javalang.parse.parse(class_wrapped)
+            input_ast = javalang.parse.parse(class_main_wrapped)
         except:
-            # this will signal to translate that error occurred
-            return None
-
+            try:
+                input_ast = javalang.parse.parse(class_wrapped)
+            except:
+                # this will signal to translate that error occurred
+                return None
     return java_router.node_to_gast(input_ast)

--- a/java/code_to_gast/java_main.py
+++ b/java/code_to_gast/java_main.py
@@ -29,7 +29,7 @@ def java_to_gast(java_input):
     try:
         # if input compiles without wrapper it includes a class which is unsupported
         input_ast = javalang.parse.parse(java_input)
-        # throw an error since classes are not supported 
+        # throw an error since classes are not supported
         return None
     except:
         try:


### PR DESCRIPTION
Old Behavior:
Input code of ```class Sample {}``` caused server error because this class would compile inside the java class wrapper

Solved by checking throwing an error if java code compiles without wrapper (this means a user typed a class) 

New Behavior:
```class Sample {}``` returns None which signifies an error which will be handled by the error handler