### PR TITLE
Hot fix show error for aug assign var java

### DIFF
--- a/java/code_to_gast/java_assign.py
+++ b/java/code_to_gast/java_assign.py
@@ -19,6 +19,8 @@ Handles increment and decrement operators
 
 def member_reference_to_gast(node):
     gast = {"type": "augAssign"}
+    if len(node.postfix_operators) == 0:
+        return {"type": "error", "value": "unsupported"}
     gast["left"] = java_router.node_to_gast(node.member)
     gast["op"] = node.postfix_operators[0]
     return gast

--- a/test/test_java_assignment.py
+++ b/test/test_java_assignment.py
@@ -14,6 +14,12 @@ class TestJavaAssignment(unittest2.TestCase):
             'int[] x = {1, 2};',
             translate.translate('int[] x = {1, 2};', 'java', 'java'))
 
+    def test_aug_assign_var(self):
+        java_input = 'int total = 0;\nint i = 3;\ntotal += i;'
+        expected = 'let total = 0\nlet i = 3\ntotal += $$E2$$'
+        self.assertEqual(expected, translate.translate(java_input, 'java',
+                                                       'js'))
+
 
 if __name__ == '__main__':
     unittest2.main()


### PR DESCRIPTION
Input:
```
int i = 1;
int total = 0;
total += i;
```

Old behavior - internal server error
New behavior - 
```
int i = 1;
int total = 0;
total += <err>
```
Error was being thrown since variables as member expressions don't have property postfix_operators